### PR TITLE
Add xserver integration of i3 WM.

### DIFF
--- a/modules/services/x11/window-managers/default.nix
+++ b/modules/services/x11/window-managers/default.nix
@@ -14,6 +14,7 @@ in
     ./twm.nix
     ./wmii.nix
     ./xmonad.nix
+    ./i3.nix
   ];
 
   options = {

--- a/modules/services/x11/window-managers/i3.nix
+++ b/modules/services/x11/window-managers/i3.nix
@@ -1,0 +1,30 @@
+{pkgs, config, ...}:
+
+let
+  inherit (pkgs.lib) mkOption mkIf;
+  cfg = config.services.xserver.windowManager.i3;
+in
+
+{
+  options = {
+    services.xserver.windowManager.i3 = {
+      enable = mkOption {
+        default = false;
+        example = true;
+        description = "Enable the i3 tiling window manager.";
+      };
+    };
+  };
+
+  config = {
+    services.xserver.windowManager = {
+      session = mkIf cfg.enable [{
+        name = "i3";
+        start = "
+          ${pkgs.i3}/bin/i3 &
+          waitPID=$!
+        ";
+      }];
+    };
+  };
+}


### PR DESCRIPTION
This allows to set i3 as the default window manager in the system configuration.
