### PR TITLE
nixos-rebuild: make 'pull' fail in case it did not pull anything.

### DIFF
--- a/modules/installer/tools/nixos-rebuild.sh
+++ b/modules/installer/tools/nixos-rebuild.sh
@@ -130,7 +130,7 @@ if [ -n "$pullManifest" -o "$action" = pull ]; then
         | grep '<string'  | sed 's^.*"\(.*\)".*^\1^g')
 
     set -o nopipefail
-    [ "$action" = pull -a $? -ne 0 ] && exit 1
+    if [ $? -ne 0 ]; then exit 1; fi
 
     mkdir -p /nix/var/nix/channel-cache
     for i in $manifests; do

--- a/modules/installer/tools/nixos-rebuild.sh
+++ b/modules/installer/tools/nixos-rebuild.sh
@@ -125,8 +125,12 @@ fi
 # Pull the manifests defined in the configuration (the "manifests"
 # attribute).  Wonderfully hacky.
 if [ -n "$pullManifest" -o "$action" = pull ]; then
+    set -o pipefail
     manifests=$(nix-instantiate --eval-only --xml --strict '<nixos>' -A manifests \
         | grep '<string'  | sed 's^.*"\(.*\)".*^\1^g')
+
+    set -o nopipefail
+    [ "$action" = pull -a $? -ne 0 ] && exit 1
 
     mkdir -p /nix/var/nix/channel-cache
     for i in $manifests; do


### PR DESCRIPTION
What do you think about this way of having 'pull' exit with error, in case it didn't pull anything?
