### PR TITLE
Add a new service module for PHP FPM.

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -100,6 +100,7 @@
   ./services/misc/nix-daemon.nix
   ./services/misc/nix-gc.nix
   ./services/misc/nixos-manual.nix
+  ./services/misc/phpfpm.nix
   ./services/misc/rogue.nix
   ./services/misc/svnserve.nix
   ./services/misc/synergy.nix

--- a/modules/services/misc/phpfpm.nix
+++ b/modules/services/misc/phpfpm.nix
@@ -1,0 +1,79 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+  cfg = config.services.phpfpm;
+  fpmCfgFile = pkgs.writeText "phpfpm.conf" fpmConf;
+  fpmConf = ''
+    [global]
+    pid = ${cfg.stateDir}/php-fpm.pid
+    error_log = ${cfg.logDir}/error.log
+    daemonize = no
+
+    [default]
+    user = ${cfg.user}
+    group = ${cfg.group}
+
+    listen = ${cfg.stateDir}/default.socket
+    pm = dynamic
+    pm.max_children = 400
+    pm.min_spare_servers = 10
+    pm.max_spare_servers = 30
+  '';
+
+  fpmPackage = pkgs.php5_3fpm;
+in {
+  options = {
+    services.phpfpm = {
+      enable = mkOption {
+        default = false;
+        description = "Whether to enable the PHP FastCGI Process Manager.";
+      };
+
+      user = mkOption {
+        default = "phpfpm";
+        description = "User account under which PHP FPM runs.";
+      };
+
+      group = mkOption {
+        default = "phpfpm";
+        description = "Group under which PHP FPM runs.";
+      };
+
+      stateDir = mkOption {
+        default = "/var/run/phpfpm";
+        description = "State directory with PID and socket files.";
+      };
+
+      logDir = mkOption {
+        default = "/var/log/phpfpm";
+        description = "Directory where to put in log files.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.extraUsers = singleton {
+      name = cfg.user;
+      description = "PHP FastCGI user";
+    };
+
+    users.extraGroups = singleton {
+      name = cfg.group;
+    };
+
+    jobs.phpfpm = {
+      startOn = "started network-interfaces";
+      stopOn = "stopping network-interfaces";
+      #buildHook = "${fpmPackage}/sbin/php-fpm -t -y ${fpmCfgFile}";
+      preStart = ''
+        install -m 0755 -o "${cfg.user}" -g "${cfg.group}" -d "${cfg.stateDir}" "${cfg.logDir}"
+        touch "${cfg.logDir}/error.log"
+        chmod 0600 "${cfg.logDir}/error.log"
+        chown "${cfg.user}:${cfg.group}" "${cfg.logDir}/error.log"
+      '';
+      exec = "${fpmPackage}/sbin/php-fpm -y ${fpmCfgFile}";
+    };
+  };
+}

--- a/modules/services/misc/phpfpm.nix
+++ b/modules/services/misc/phpfpm.nix
@@ -15,17 +15,22 @@ let
   '';
 
   getPoolContent = pool: let
+    iniEsc = val:
+      if builtins.isString val then "\"${escape ["\""] val}\""
+      else if val == true then "on"
+      else if val == false then "off"
+      else toString val;
     dotNS = ns: if ns != "" then (ns + ".") else "";
     traverse = p: ns: let
       travMap = key: val:
         if ns == "" && (key == "env" || (substring 0 4 key) == "php_") then
-          let l = mapAttrsToList (k: v: "${key}[${k}] = ${toString v}") val;
+          let l = mapAttrsToList (k: v: "${key}[${k}] = ${iniEsc v}") val;
           in concatStringsSep "\n" l
         else if key == "value" then
-          "${ns} = ${toString val}"
+          "${ns} = ${iniEsc val}"
         else if isAttrs val then
           traverse val "${dotNS ns}${key}"
-        else "${dotNS ns}${key} = ${toString val}";
+        else "${dotNS ns}${key} = ${iniEsc val}";
     in concatStringsSep "\n" (mapAttrsToList travMap p);
   in traverse pool "";
 

--- a/modules/services/misc/phpfpm.nix
+++ b/modules/services/misc/phpfpm.nix
@@ -4,8 +4,7 @@ with pkgs.lib;
 
 let
   cfg = config.services.phpfpm;
-  fpmCfgFile = pkgs.writeText "phpfpm.conf" fpmConf;
-  fpmConf = ''
+  fpmCfgFile = pkgs.writeText "phpfpm.conf" ''
     [global]
     pid = ${cfg.stateDir}/php-fpm.pid
     error_log = ${cfg.logDir}/error.log

--- a/modules/services/misc/phpfpm.nix
+++ b/modules/services/misc/phpfpm.nix
@@ -18,7 +18,10 @@ let
     dotNS = ns: if ns != "" then (ns + ".") else "";
     traverse = p: ns: let
       travMap = key: val:
-        if key == "value" then
+        if ns == "" && (key == "env" || (substring 0 4 key) == "php_") then
+          let l = mapAttrsToList (k: v: "${key}[${k}] = ${toString v}") val;
+          in concatStringsSep "\n" l
+        else if key == "value" then
           "${ns} = ${toString val}"
         else if isAttrs val then
           traverse val "${dotNS ns}${key}"
@@ -80,6 +83,10 @@ in {
           This is specified by using an attribute set which maps roughly 1:1
           to ini-file syntax, with the exception that the main value of a
           namespace has to be specified by an attribute called 'value'.
+
+          In addition, attributes called 'env' or starting with 'php_' are
+          formatted with square brackets, like for example 'env[TMP] = /tmp',
+          which corresponds to 'env.TMP = "/tmp"'.
         '';
       };
     };


### PR DESCRIPTION
This adds a service for the PHP FastCGI Process Manager which replaces PHPs FastCGI module in future versions.

The service needs PHP with compiled in FPM, and thus is based on MarcWeber's work in his experimental/php branch, so it might make sense to either cherry-pick and/or modify MarcWeber/nixpkgs@3d45a854eb50a2895807e4cc33c548af8c755de4 or add `--enable-fpm` prior to merging in this commit.
