### PR TITLE
fix init-script-builder

### DIFF
--- a/modules/installer/init-script/init-script-builder.sh
+++ b/modules/installer/init-script/init-script-builder.sh
@@ -1,4 +1,3 @@
-
 #! @bash@/bin/sh -e
 
 shopt -s nullglob
@@ -44,7 +43,7 @@ addEntry() {
 
     configurationCounter=$((configurationCounter + 1))
 
-    local stage2=$(readlink $path/init)
+    local stage2=$path/init
 
     content="$(
       echo "#!/bin/sh"


### PR DESCRIPTION
The main link (first addEntry call, $defaultConfig) is no longer a symlink. Additional generations still are - but writing the system-XX-link/init does not hurt.
