### PR TITLE
stage-1: Add option to load keymap during bootup.

### DIFF
--- a/modules/system/boot/stage-1-init.sh
+++ b/modules/system/boot/stage-1-init.sh
@@ -147,6 +147,10 @@ modprobe scsi_wait_scan || true
 udevadm settle || true
 
 
+# Load boot-time keymap before any LVM/LUKS initialization
+@extraUtils@/bin/busybox loadkmap < "@busyboxKeymap@"
+
+
 # XXX: Use case usb->lvm will still fail, usb->luks->lvm is covered
 @preLVMCommands@
 

--- a/modules/system/boot/stage-1.nix
+++ b/modules/system/boot/stage-1.nix
@@ -27,15 +27,6 @@ let
       ";
     };
 
-    boot.initrd.loadConsoleKeyMap = mkOption {
-      default = false;
-      type = with types; bool;
-      description = ''
-        Load i18n.consoleKeyMap at boot time. This is especially useful if you
-        bring together a non-QWERTY keyboard with a LUKS password prompt.
-      '';
-    };
-
     boot.initrd.checkJournalingFS = mkOption {
       default = true;
       type = types.bool;
@@ -293,17 +284,12 @@ let
 
     isExecutable = true;
 
-    inherit udevConf extraUtils modulesClosure;
+    inherit udevConf busyboxKeymap extraUtils modulesClosure;
 
     inherit (config.boot) resumeDevice devSize runSize;
 
     inherit (config.boot.initrd) checkJournalingFS
-      postDeviceCommands postMountCommands kernelModules;
-
-    preLVMCommands = (optionalString config.boot.initrd.loadConsoleKeyMap ''
-        # load boot-time keymap before any LVM/LUKS initialization
-        ${extraUtils}/bin/busybox loadkmap < "${busyboxKeymap}"
-      '') + config.boot.initrd.preLVMCommands;
+      preLVMCommands postDeviceCommands postMountCommands kernelModules;
 
     fsInfo =
       let f = fs: [ fs.mountPoint (if fs.device != null then fs.device else "/dev/disk/by-label/${fs.label}") fs.fsType fs.options ];


### PR DESCRIPTION
Load the configured keyboard layout (i18n.consoleKeyMap) early in stage 1.
Configurable by `boot.initrd.loadConsoleKeyMap`, which is set to false by default.
