### PR TITLE
mingetty: Option to not restart on service change.

### DIFF
--- a/modules/services/ttys/mingetty.nix
+++ b/modules/services/ttys/mingetty.nix
@@ -46,6 +46,14 @@ with pkgs.lib;
         '';
       };
 
+      dontRestart = mkOption {
+        default = false;
+        description = ''
+          Don't restart mingetty processes as this will result in active
+          sessions to be logged out, for example on activation of the system's
+          configuration.
+        '';
+      };
     };
 
   };
@@ -68,6 +76,8 @@ with pkgs.lib;
       path = [ pkgs.mingetty ];
 
       exec = "mingetty --loginprog=${pkgs.shadow}/bin/login --noclear ${tty}";
+
+      restartIfChanged = !config.services.mingetty.dontRestart;
 
       environment.LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
 

--- a/modules/services/ttys/mingetty.nix
+++ b/modules/services/ttys/mingetty.nix
@@ -45,15 +45,6 @@ with pkgs.lib;
           how to proceed.
         '';
       };
-
-      dontRestart = mkOption {
-        default = false;
-        description = ''
-          Don't restart mingetty processes as this will result in active
-          sessions to be logged out, for example on activation of the system's
-          configuration.
-        '';
-      };
     };
 
   };
@@ -77,7 +68,7 @@ with pkgs.lib;
 
       exec = "mingetty --loginprog=${pkgs.shadow}/bin/login --noclear ${tty}";
 
-      restartIfChanged = !config.services.mingetty.dontRestart;
+      restartIfChanged = false;
 
       environment.LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
 


### PR DESCRIPTION
This especially annoyed me whenver I was doing nixos-rebuild switch and getting logged out on all consoles. With this there now is `services.mingetty.dontRestart` for heavy VT users to deactivate this behaviour.
