### PR TITLE
Fix upgrades for machines with non-writeable /dev/console

### DIFF
--- a/modules/system/upstart/upstart.nix
+++ b/modules/system/upstart/upstart.nix
@@ -45,9 +45,7 @@ let
           ${optionalString (job.console != "") "console ${job.console}"}
 
           pre-start script
-            ${optionalString (job.console == "") ''
-              exec >> ${log} 2>&1
-            ''}
+            ${optionalString (job.console != "") "echo || "} exec >> ${log} 2>&1
             ln -sfn "$(readlink -f "/etc/init/${job.name}.conf")" /var/run/upstart-jobs/${job.name}
             ${optionalString (job.preStart != "") ''
               source ${jobHelpers}
@@ -60,9 +58,7 @@ let
             else if job.script != "" then
               ''
                 script
-                  ${optionalString (job.console == "") ''
-                    exec >> ${log} 2>&1
-                  ''}
+                  ${optionalString (job.console != "") "echo || "} exec >> ${log} 2>&1
                   source ${jobHelpers}
                   ${job.script}
                 end script
@@ -83,9 +79,7 @@ let
 
           ${optionalString (job.postStart != "") ''
             post-start script
-              ${optionalString (job.console == "") ''
-                exec >> ${log} 2>&1
-              ''}
+              ${optionalString (job.console != "") "echo || "} exec >> ${log} 2>&1
               source ${jobHelpers}
               ${job.postStart}
             end script
@@ -98,9 +92,7 @@ let
              # (upstart 0.6.5, job.c:562)
             optionalString (job.preStop != "") (assert hasMain; ''
             pre-stop script
-              ${optionalString (job.console == "") ''
-                exec >> ${log} 2>&1
-              ''}
+              ${optionalString (job.console != "") "echo || "} exec >> ${log} 2>&1
               source ${jobHelpers}
               ${job.preStop}
             end script
@@ -108,9 +100,7 @@ let
 
           ${optionalString (job.postStop != "") ''
             post-stop script
-              ${optionalString (job.console == "") ''
-                exec >> ${log} 2>&1
-              ''}
+              ${optionalString (job.console != "") "echo || "} exec >> ${log} 2>&1
               source ${jobHelpers}
               ${job.postStop}
             end script


### PR DESCRIPTION
On my cluster, /dev/console points to DRAC's Serial-over-LAN. However, some of the machines had SoL disabled in BIOS, which meant /dev/console was not writeable. Either way, relying on /dev/console is wrong (see also http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=546743). With existing setup, since all upstart scripts run with set -e, if /dev/console gives EIO, things start to fail and make profile activation impossible:
initctl: Event failed

This thing at least fixes the problem with things dying. The useless diagnostics are a separate (and probably upstream) issue...
