### PR TITLE
Shellaliases

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -39,6 +39,7 @@
   ./programs/blcr.nix
   ./programs/info.nix
   ./programs/shadow.nix
+  ./programs/shell.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/wvdial.nix

--- a/modules/programs/bash/bash.nix
+++ b/modules/programs/bash/bash.nix
@@ -25,6 +25,9 @@ let
     fi
   '';
 
+  shellAliases = concatStringsSep "\n" (
+    mapAttrsFlatten (k: v: "alias ${k}='${v}'") config.environment.shellAliases
+  );
 
   options = {
 
@@ -63,11 +66,11 @@ in
       { # /etc/bashrc: executed every time a bash starts. Sources
         # /etc/profile to ensure that the system environment is
         # configured properly.
-         source = pkgs.substituteAll {
-           src = ./bashrc.sh;
-           inherit initBashCompletion;
-         };
-         target = "bashrc";
+        source = pkgs.substituteAll {
+          src = ./bashrc.sh;
+          inherit initBashCompletion shellAliases;
+        };
+        target = "bashrc";
       }
 
       { # Configuration for readline in bash.
@@ -75,6 +78,13 @@ in
         target = "inputrc";
       }
     ];
+
+  environment.shellAliases = {
+    ls = "ls --color=tty";
+    ll = "ls -l";
+    l = "ls -alh";
+    which = "type -P";
+  };
 
   system.build.binsh = pkgs.bashInteractive;
 

--- a/modules/programs/bash/bashrc.sh
+++ b/modules/programs/bash/bashrc.sh
@@ -29,8 +29,4 @@ fi
 
 @initBashCompletion@
 
-# Some aliases.
-alias ls="ls --color=tty"
-alias ll="ls -l"
-alias l="ls -alh"
-alias which="type -P"
+@shellAliases@

--- a/modules/programs/shell.nix
+++ b/modules/programs/shell.nix
@@ -1,0 +1,25 @@
+# This module defines global configuration for the shells.
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+{
+  options = {
+    environment.shellAliases = mkOption {
+      type = types.attrs; # types.attrsOf types.stringOrPath;
+      default = {};
+      example = {
+        ll = "ls -lh";
+      };
+      description = ''
+        An attribute set that maps aliases (the top level attribute names in
+        this option) to command strings or directly to build outputs. The
+        aliases are added to all users' shells.
+      '';
+    };
+  };
+
+  config = {
+  };
+}


### PR DESCRIPTION
Option for adding shell aliases to the environment. It works fine for bash, but no support for zsh yet. Also, if the same alias is defined twice they will be merged, which is not what you want. Instead, one of them should take precedence. I'd be grateful if someone could point out the correct option declaration to achieve that...
