### PR TITLE
network-manager: Big overhaul

### DIFF
--- a/modules/misc/ids.nix
+++ b/modules/misc/ids.nix
@@ -126,6 +126,7 @@ in
     clamav = 51;
     fprot = 52;
     wwwrun = 54;
+    networkmanager = 56;
 
     # When adding a gid, make sure it doesn't match an existing uid.
 


### PR DESCRIPTION
- Add group 'networkmanager' and implement polkit configuration
  that allows users in this group to make persistent, system-wide
  changes to NetworkManager settings.
  - Add support for ModemManager. 3G modems should work out of the
    box now (it does for me...). This introduces a dependency on
    pkgs.modemmanager.
  - Write NetworkManger config file to Nix store, and let the
    daemon use it from there.
