### PR TITLE
hostapd module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -129,6 +129,7 @@
   ./services/networking/gnunet.nix
   ./services/networking/gogoclient.nix
   ./services/networking/gvpe.nix
+  ./services/networking/hostapd.nix
   ./services/networking/ifplugd.nix
   ./services/networking/ircd-hybrid/default.nix
   ./services/networking/nat.nix

--- a/modules/services/networking/hostapd.nix
+++ b/modules/services/networking/hostapd.nix
@@ -52,7 +52,7 @@ in
       enable = mkOption {
         default = false;
         description = ''
-          enable putting a wireless interface into infrastructure mode,
+          Enable putting a wireless interface into infrastructure mode,
           allowing other wireless devices to associate with the wireless interface and do
           wireless networking. A simple access point will enable hostapd.wpa, and
           hostapd.wpa_passphrase, hostapd.ssid, dhcpd on the wireless interface to
@@ -107,19 +107,24 @@ in
         example = "network";
         type = types.string;
         description = "members of this group can control hostapd";
-        };
+      };
 
       wpa = mkOption {
         default = true;
         description = "enable WPA (IEEE 802.11i/D3.0) to authenticate to the access point";
-        };
+      };
 
       wpaPassphrase = mkOption {
         default = "my_sekret";
         example = "any_64_char_string";
         type = types.string;
-        description = "WPA-PSK (pre-shared-key) passphrase. Clients will need this passphrase to associate with this access point";
-        };
+        description = 
+          ''
+          WPA-PSK (pre-shared-key) passphrase. Clients will need this
+          passphrase to associate with this access point. Warning: This passphrase will
+          get put into a world-readable file in the nix store. 
+          '';
+      };
 
       extraCfg = mkOption {
         default = "";
@@ -130,9 +135,9 @@ in
           '';
         type = types.string;
         description = "Extra configuration options to put in the hostapd.conf";
-        };
       };
     };
+  };
 
 
   ###### implementation
@@ -144,11 +149,7 @@ in
     jobs.hostapd =
       { startOn = "started network-interfaces";
         stopOn = "stopping network-interfaces";
-
-        script =
-          ''
-            exec ${pkgs.hostapd}/bin/hostapd ${configFile}
-          '';
+        exec = "${pkgs.hostapd}/bin/hostapd ${configFile}";
       };
   };
 }

--- a/modules/services/networking/hostapd.nix
+++ b/modules/services/networking/hostapd.nix
@@ -1,0 +1,154 @@
+{ config, pkgs, ... }:
+
+# TODO:
+#
+# asserts 
+#   ensure that the nl80211 module is loaded/compiled in the kernel
+#   hwMode must be a/b/g
+#   channel must be between 1 and 13 (maybe)
+#   wpa_supplicant and hostapd on the same wireless interface doesn't make any sense
+#   perhaps an assertion that there is a dhcp server and a dns server on the IP address serviced by the hostapd?
+
+with pkgs.lib;
+
+let
+
+  cfg = config.services.hostapd;
+  
+  configFile = pkgs.writeText "hostapd.conf"  
+    ''
+    interface=${cfg.interface}
+    driver=${cfg.driver}
+    ssid=${cfg.ssid}
+    hw_mode=${cfg.hwMode}
+    channel=${toString cfg.channel}
+
+    # logging (debug level)
+    logger_syslog=-1
+    logger_syslog_level=2
+    logger_stdout=-1
+    logger_stdout_level=2
+
+    ctrl_interface=/var/run/hostapd
+    ctrl_interface_group=${cfg.group}
+
+    ${if cfg.wpa then ''
+      wpa=1
+      wpa_passphrase=${cfg.wpaPassphrase}
+      '' else ""}
+
+    ${cfg.extraCfg}
+    '' ;
+
+in
+
+{
+  ###### interface
+
+  options = {
+
+    services.hostapd = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          enable putting a wireless interface into infrastructure mode,
+          allowing other wireless devices to associate with the wireless interface and do
+          wireless networking. A simple access point will enable hostapd.wpa, and
+          hostapd.wpa_passphrase, hostapd.ssid, dhcpd on the wireless interface to
+          provide IP addresses to the associated stations, and nat (from the wireless
+          interface to an upstream interface). 
+        '';
+      };
+
+      interface = mkOption {
+        default = "";
+        example = "wlan0";
+        description = ''
+          The interfaces <command>hostapd</command> will use. 
+        '';
+      };
+
+      driver = mkOption {
+        default = "nl80211";
+        example = "hostapd";
+        type = types.string;
+        description = "Which driver hostapd will use. Most things will probably use the default.";
+      };
+
+      ssid = mkOption {
+        default = "nixos";
+        example = "mySpecialSSID";
+        type = types.string;
+        description = "SSID to be used in IEEE 802.11 management frames.";
+      };
+
+      hwMode = mkOption {
+        default = "b";
+        example = "g";
+        type = types.string;
+        description = "Operation mode (a = IEEE 802.11a, b = IEEE 802.11b, g = IEEE 802.11g";
+      };
+
+      channel = mkOption { 
+        default = 7;
+        example = 11;
+        type = types.int;
+        description = 
+          ''
+          Channel number (IEEE 802.11)
+          Please note that some drivers do not use this value from hostapd and the
+          channel will need to be configured separately with iwconfig.
+          '';
+      };
+
+      group = mkOption {
+        default = "wheel";
+        example = "network";
+        type = types.string;
+        description = "members of this group can control hostapd";
+        };
+
+      wpa = mkOption {
+        default = true;
+        description = "enable WPA (IEEE 802.11i/D3.0) to authenticate to the access point";
+        };
+
+      wpaPassphrase = mkOption {
+        default = "my_sekret";
+        example = "any_64_char_string";
+        type = types.string;
+        description = "WPA-PSK (pre-shared-key) passphrase. Clients will need this passphrase to associate with this access point";
+        };
+
+      extraCfg = mkOption {
+        default = "";
+        example = ''
+          auth_algo=0
+          ieee80211n=1
+          ht_capab=[HT40-][SHORT-GI-40][DSSS_CCK-40]
+          '';
+        type = types.string;
+        description = "Extra configuration options to put in the hostapd.conf";
+        };
+      };
+    };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages =  [ pkgs.hostapd ];
+
+    jobs.hostapd =
+      { startOn = "started network-interfaces";
+        stopOn = "stopping network-interfaces";
+
+        script =
+          ''
+            exec ${pkgs.hostapd}/bin/hostapd ${configFile}
+          '';
+      };
+  };
+}


### PR DESCRIPTION
This module contains enough 'basic' functionality (in configuration) to set up a pretty basic access point. 

The functionality is complete and using the module according to it's documentation works (as well as the underlying drivers work: I've been running an ath9k access point for a while, and the kernel drivers need some work). 

It could use some more assertions, like: ensure that a dhcpd is running on the wireless interface, etc. 
