### PR TITLE
making ati proprietary drivers work again

### DIFF
--- a/modules/services/x11/xserver.nix
+++ b/modules/services/x11/xserver.nix
@@ -343,7 +343,8 @@ in
       optional (elem "virtualbox" driverNames) kernelPackages.virtualboxGuestAdditions ++
       optional (elem "ati_unfree" driverNames) kernelPackages.ati_drivers_x11;
 
-    environment.etc = optionals cfg.exportConfiguration
+    environment.etc =
+    (optionals cfg.exportConfiguration
       [ { source = "${configFile}";
           target = "X11/xorg.conf";
         }
@@ -351,7 +352,15 @@ in
         { source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
           target = "X11/xkb";
         }
-      ];
+      ])
+    ++ (optionals (elem "ati_unfree" driverNames) [
+
+        # according toiive on #ati you don't need the pcs, it is like registry... keeps old stuff to make your
+        # life harder ;) Still it seems to be required
+        { source = "${kernelPackages.ati_drivers_x11}/etc/ati";
+          target = "ati";
+        }
+    ]);
 
     environment.x11Packages =
       [ xorg.xorgserver
@@ -420,6 +429,8 @@ in
                 "ln -sf ${kernelPackages.nvidia_x11_legacy96} /run/opengl-driver"
               else if elem "nvidiaLegacy173" driverNames then
                 "ln -sf ${kernelPackages.nvidia_x11_legacy173} /run/opengl-driver"
+              else if elem "ati_unfree" driverNames then
+                "ln -sf ${kernelPackages.ati_drivers_x11} /run/opengl-driver"
               else if cfg.driSupport then
                 "ln -sf ${pkgs.mesa} /run/opengl-driver"
               else ""


### PR DESCRIPTION
However SLIM is still broken and you have to create a
/usr/lib/dri/fglrx_dri.so symlink pointing to
/run/opengl-driver/lib/fglrx_dri.so

At least fgl_glxgears shows 10 times more frames per second now
