### PR TITLE
Include support for Apache HTTP server 2.4.

### DIFF
--- a/modules/services/web-servers/apache-httpd/default.nix
+++ b/modules/services/web-servers/apache-httpd/default.nix
@@ -373,7 +373,9 @@ let
     ${let
         ports = map getPort allHosts;
         uniquePorts = uniqList {inputList = ports;};
-      in concatMapStrings (port: "NameVirtualHost *:${toString port}\n") uniquePorts
+        isNeeded = versionOlder httpd.version "2.4";
+        directives = concatMapStrings (port: "NameVirtualHost *:${toString port}\n") uniquePorts;
+      in optionalString isNeeded directives
     }
 
     ${let

--- a/modules/services/web-servers/apache-httpd/default.nix
+++ b/modules/services/web-servers/apache-httpd/default.nix
@@ -114,6 +114,7 @@ let
       "vhost_alias" "negotiation" "dir" "imagemap" "actions" "speling"
       "userdir" "alias" "rewrite" "proxy" "proxy_http"
     ]
+    ++ optional (!versionOlder httpd.version "2.4") "mpm_${mainCfg.multiProcessingModule}"
     ++ (if mainCfg.multiProcessingModule == "prefork" then [ "cgi" ] else [ "cgid" ])
     ++ optional enableSSL "ssl"
     ++ extraApacheModules;

--- a/modules/services/web-servers/apache-httpd/default.nix
+++ b/modules/services/web-servers/apache-httpd/default.nix
@@ -114,7 +114,10 @@ let
       "vhost_alias" "negotiation" "dir" "imagemap" "actions" "speling"
       "userdir" "alias" "rewrite" "proxy" "proxy_http"
     ]
-    ++ optional (!versionOlder httpd.version "2.4") "mpm_${mainCfg.multiProcessingModule}"
+    ++ optionals (!versionOlder httpd.version "2.4") [
+      "mpm_${mainCfg.multiProcessingModule}"
+      "unixd"
+    ]
     ++ (if mainCfg.multiProcessingModule == "prefork" then [ "cgi" ] else [ "cgid" ])
     ++ optional enableSSL "ssl"
     ++ extraApacheModules;

--- a/modules/services/web-servers/apache-httpd/default.nix
+++ b/modules/services/web-servers/apache-httpd/default.nix
@@ -101,7 +101,8 @@ let
       "auth_basic" "auth_digest"
 
       # Authentication: is the user who he claims to be?
-      "authn_file" "authn_dbm" "authn_anon" "authn_alias"
+      "authn_file" "authn_dbm" "authn_anon"
+      (if versionOlder httpd.version "2.3" then "authn_alias" else "authn_core")
 
       # Authorization: is the user allowed access?
       "authz_user" "authz_groupfile" "authz_host"

--- a/modules/services/web-servers/apache-httpd/default.nix
+++ b/modules/services/web-servers/apache-httpd/default.nix
@@ -303,6 +303,10 @@ let
 
     ServerRoot ${httpd}
 
+    ${optionalString (!versionOlder httpd.version "2.4") ''
+      DefaultRuntimeDir ${mainCfg.stateDir}/runtime
+    ''}
+
     PidFile ${mainCfg.stateDir}/httpd.pid
 
     ${optionalString (mainCfg.multiProcessingModule != "prefork") ''
@@ -636,6 +640,10 @@ in
           ''
             mkdir -m 0750 -p ${mainCfg.stateDir}
             chown root.${mainCfg.group} ${mainCfg.stateDir}
+            ${optionalString (!versionOlder httpd.version "2.4") ''
+              mkdir -m 0750 -p "${mainCfg.stateDir}/runtime"
+              chown root.${mainCfg.group} "${mainCfg.stateDir}/runtime"
+            ''}
             mkdir -m 0700 -p ${mainCfg.logDir}
 
             ${optionalString (mainCfg.documentRoot != null)


### PR DESCRIPTION
We already have `pkgs.apacheHttpd_2_4` as an example for the `package` option, so we really should support version 2.4.

I'm not quite sure if everyone feels okay that I've used `versionOlder`, so please suggest something better if it feels wrong to you. Yes, I already thought about duplicating the file with `-2.4`, but I really don't like that whole duplication approach in general and especially in this case the duplication is really quite large (and it fact will be difficult to maintain, not to mention code smell).
