### PR TITLE
a zfs module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -220,6 +220,7 @@
   ./tasks/filesystems/reiserfs.nix
   ./tasks/filesystems/vfat.nix
   ./tasks/filesystems/xfs.nix
+  ./tasks/filesystems/zfs.nix
   ./tasks/kbd.nix
   ./tasks/lvm.nix
   ./tasks/network-interfaces.nix

--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -1,41 +1,68 @@
 { config, pkgs, ... }:
+#
+# todo:
+#   - crontab for scrubs, etc
+#   - zfs tunables
+#   - /etc/zfs/zpool.cache handling
+
 
 with pkgs.lib;
 
 let
 
+  cfgSpl = config.environment.spl;
   inInitrd = any (fs: fs == "zfs") config.boot.initrd.supportedFilesystems;
+  inSystem = any (fs: fs == "zfs") config.boot.supportedFilesystems;
   kernel = config.boot.kernelPackages;
 
 in
 
 {
+
+  ###### interface
+  
+  options = { 
+    environment.spl.hostid = mkOption { 
+      default = "";
+      example = "0xdeadbeef";
+      description = ''
+        ZFS uses a system's hostid to determine if a storage pool (zpool) is
+        native to this system, and should thus be imported automatically.
+        Unfortunately, this hostid can change under linux from boot to boot (by
+        changing network adapaters, for instance). Specify a unique 32 bit hostid in
+        hex here for zfs to prevent getting a random hostid between boots and having to
+        manually import pools.
+      '';
+    };
+  };
+
   ###### implementation
 
-  config = mkIf (any (fs: fs == "zfs") config.boot.supportedFilesystems) {
+  config = mkIf ( inInitrd || inSystem ) {
 
-    boot.kernelModules = [ "spl" "zfs" ] ;
-    boot.extraModulePackages = [ kernel.zfs kernel.spl ];
+    boot = { 
+      kernelModules = [ "spl" "zfs" ] ;
+      extraModulePackages = [ kernel.zfs kernel.spl ];
+      extraModprobeConfig = mkIf (cfgSpl.hostid != "") "options spl spl_hostid=${cfgSpl.hostid}";
+    };
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "spl" "zfs" ] ;
+    boot.initrd = mkIf inInitrd { 
+      kernelModules = [ "spl" "zfs" ] ;
+      extraUtilsCommands =
+        ''
+          cp -v ${kernel.zfs}/sbin/zfs $out/sbin
+          cp -v ${kernel.zfs}/sbin/zdb $out/sbin
+          cp -v ${kernel.zfs}/sbin/zpool $out/sbin
+        '';
+      postDeviceCommands =
+        ''
+          zpool import -f -a -d /dev
+          zfs mount -a
+        '';
+    };
 
-    boot.initrd.extraUtilsCommands = mkIf inInitrd
-      ''
-        cp -v ${kernel.zfs}/sbin/zfs $out/sbin
-        cp -v ${kernel.zfs}/sbin/zdb $out/sbin
-        cp -v ${kernel.zfs}/sbin/zpool $out/sbin
-      '';
-
-    boot.initrd.postDeviceCommands = mkIf inInitrd
-      ''
-        zpool import -f -a -d /dev
-        zfs mount -a
-      '';
-
-    system.fsPackages = [ kernel.zfs ];
-
+    system.fsPackages = [ kernel.zfs ];                  # XXX: needed? zfs doesn't have a fsck
     environment.systemPackages = [ kernel.zfs ];
-
-    services.udev.packages = [ kernel.zfs ];
+    services.udev.packages = [ kernel.zfs ];             # to hook zvol naming, etc. 
   };
 }

--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -1,0 +1,40 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+
+  inInitrd = any (fs: fs == "zfs") config.boot.initrd.supportedFilesystems;
+  kernel = config.boot.kernelPackages;
+
+in
+
+{
+  ###### implementation
+
+  config = mkIf (any (fs: fs == "zfs") config.boot.supportedFilesystems) {
+
+    boot.kernelModules = [ "spl" "zavl" "zcommon" "zfs" "zlib_deflate" "znvpair" "zunicode" ] ;
+
+    boot.initrd.kernelModules = mkIf inInitrd [ "spl" "zavl" "zcommon" "zfs" "zlib_deflate" "znvpair" "zunicode" ] ;
+
+    boot.initrd.extraUtilsCommands = mkIf inInitrd
+      ''
+        cp -v ${kernel.zfs}/sbin/zfs $out/sbin
+        cp -v ${kernel.zfs}/sbin/zdb $out/sbin
+        cp -v ${kernel.zfs}/sbin/zpool $out/sbin
+      '';
+
+    boot.initrd.postDeviceCommands = mkIf inInitrd
+      ''
+        zpool import -f -a -d /dev
+        zfs mount -a
+      '';
+
+    system.fsPackages = [ kernel.zfs ];
+
+    environment.systemPackages = [ kernel.zfs ];
+
+    services.udev.packages = [ kernel.zfs ];
+  };
+}

--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -10,7 +10,7 @@ with pkgs.lib;
 
 let
 
-  cfgSpl = config.environment.spl;
+  cfgSpl = config.boot.spl;
   inInitrd = any (fs: fs == "zfs") config.boot.initrd.supportedFilesystems;
   inSystem = any (fs: fs == "zfs") config.boot.supportedFilesystems;
   kernel = config.boot.kernelPackages;
@@ -22,7 +22,7 @@ in
   ###### interface
   
   options = { 
-    environment.spl.hostid = mkOption { 
+    boot.spl.hostid = mkOption { 
       default = "";
       example = "0xdeadbeef";
       description = ''

--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -14,9 +14,10 @@ in
 
   config = mkIf (any (fs: fs == "zfs") config.boot.supportedFilesystems) {
 
-    boot.kernelModules = [ "spl" "zavl" "zcommon" "zfs" "zlib_deflate" "znvpair" "zunicode" ] ;
+    boot.kernelModules = [ "spl" "zfs" ] ;
+    boot.extraModulePackages = [ kernel.zfs kernel.spl ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "spl" "zavl" "zcommon" "zfs" "zlib_deflate" "znvpair" "zunicode" ] ;
+    boot.initrd.kernelModules = mkIf inInitrd [ "spl" "zfs" ] ;
 
     boot.initrd.extraUtilsCommands = mkIf inInitrd
       ''


### PR DESCRIPTION
Here's a first pass at a  zfs filesystem task. 

It adds the necessary kernel modules and binaries to the system, It adds the udev rules for naming zvols according to the zfs name (instead of a random name). This is sufficient for using zfs for home directories, or mass storage, zvols for VMs. 

I haven't tested the initrd stuff. Since the zfs userland and kernel modules do some very unsavory stuff (like calling gawk from a kernel module), it might be necessary to pull in more libraries and binaries into the initrd image.  Maybe I should just pull it out the initrd stuff, but I'd like to get to the point where I can use the installer to install nix on a zfs root. 

nits:
- zfs doesn't really do very well with less than 2GiB of memory
- zfs doesn't really do very well on 32 bit systems
- the 'environment.spl.hostid' option probably should be hung off a different branch of the options tree
- the initrd stuff is untested
