### PR TITLE
timezone should be taken from recent tzdata rather than glibc

### DIFF
--- a/modules/config/timezone.nix
+++ b/modules/config/timezone.nix
@@ -27,7 +27,7 @@ with pkgs.lib;
     environment.shellInit =
       ''
         export TZ=${config.time.timeZone}
-        export TZDIR=${pkgs.glibc}/share/zoneinfo
+        export TZDIR=${pkgs.tzdata}/share/zoneinfo
       '';
 
     environment.etc = singleton


### PR DESCRIPTION
The Europe/Moscow timezone is wrong since nixos uses glibc provided zoneinfo.

$ echo $TZDIR ; date; TZDIR=/nix/store/npzk4ymnr62cm8d7gm0qak8wlxdvjlfr-tzdata-2012f/share/zoneinfo date
/nix/store/cj7a81wsm1ijwwpkks3725661h3263p5-glibc-2.13/share/zoneinfo
Sat Nov  3 13:12:38 MSK 2012
Sat Nov  3 14:12:38 MSK 2012
