### PR TITLE
No aufs

### DIFF
--- a/modules/installer/cd-dvd/iso-image.nix
+++ b/modules/installer/cd-dvd/iso-image.nix
@@ -194,25 +194,14 @@ in
 
   boot.initrd.availableKernelModules = [ "squashfs" "iso9660" ];
 
-  boot.initrd.kernelModules = [ "loop" "fuse" ];
+  boot.initrd.kernelModules = [ "loop" ];
 
   boot.kernelModules = pkgs.stdenv.lib.optional config.isoImage.makeEfiBootable "efivars";
-
-  # Need unionfs-fuse
-  boot.initrd.extraUtilsCommands = ''
-    cp -v ${pkgs.fuse}/lib/libfuse* $out/lib
-    cp -v ${pkgs.unionfs-fuse}/bin/unionfs $out/bin
-  '';
 
   # In stage 1, mount a tmpfs on top of / (the ISO image) and
   # /nix/store (the squashfs image) to make this a live CD.
   boot.initrd.postMountCommands =
     ''
-      # Hacky!!! fuse hard-codes the path to mount
-      mkdir -p /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
-      ln -s $(which mount) /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
-      ln -s $(which umount) /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
-
       mkdir -p /unionfs-chroot$targetRoot
       mount --rbind $targetRoot /unionfs-chroot$targetRoot
 
@@ -318,7 +307,7 @@ in
     '';
 
   # Add vfat support to the initrd to enable people to copy the
-  # contents of the CD to a bootable USB stick.
-  boot.initrd.supportedFilesystems = [ "vfat" ];
+  # contents of the CD to a bootable USB stick. Need unionfs-fuse for union mounts
+  boot.initrd.supportedFilesystems = [ "vfat" "unionfs-fuse" ];
     
 }

--- a/modules/installer/cd-dvd/iso-image.nix
+++ b/modules/installer/cd-dvd/iso-image.nix
@@ -202,20 +202,20 @@ in
   # /nix/store (the squashfs image) to make this a live CD.
   boot.initrd.postMountCommands =
     ''
-      mkdir -p /unionfs-chroot$targetRoot
-      mount --rbind $targetRoot /unionfs-chroot$targetRoot
+      mkdir -p /unionfs-chroot/ro-root
+      mount --rbind $targetRoot /unionfs-chroot/ro-root
 
-      mkdir /unionfs-chroot/mnt-root-tmpfs
-      mount -t tmpfs -o "mode=755" none /unionfs-chroot/mnt-root-tmpfs
+      mkdir /unionfs-chroot/rw-root
+      mount -t tmpfs -o "mode=755" none /unionfs-chroot/rw-root
       mkdir /mnt-root-union
-      unionfs -o allow_other,cow,chroot=/unionfs-chroot /mnt-root-tmpfs=RW:$targetRoot=RO /mnt-root-union
+      unionfs -o allow_other,cow,chroot=/unionfs-chroot /rw-root=RW:/ro-root=RO /mnt-root-union
       oldTargetRoot=$targetRoot
       targetRoot=/mnt-root-union
 
-      mkdir /unionfs-chroot/mnt-store-tmpfs
-      mount -t tmpfs -o "mode=755" none /unionfs-chroot/mnt-store-tmpfs
+      mkdir /unionfs-chroot/rw-store
+      mount -t tmpfs -o "mode=755" none /unionfs-chroot/rw-store
       mkdir -p $oldTargetRoot/nix/store
-      unionfs -o allow_other,cow,nonempty,chroot=/unionfs-chroot /mnt-store-tmpfs=RW:$oldTargetRoot/nix/store=RO /mnt-root-union/nix/store
+      unionfs -o allow_other,cow,nonempty,chroot=/unionfs-chroot /rw-store=RW:/ro-root/nix/store=RO /mnt-root-union/nix/store
     '';
 
   # Closures to be copied to the Nix store on the CD, namely the init

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -214,6 +214,7 @@
   ./tasks/filesystems/ext.nix
   ./tasks/filesystems/nfs.nix
   ./tasks/filesystems/reiserfs.nix
+  ./tasks/filesystems/unionfs-fuse.nix
   ./tasks/filesystems/vfat.nix
   ./tasks/filesystems/xfs.nix
   ./tasks/kbd.nix

--- a/modules/system/boot/kernel.nix
+++ b/modules/system/boot/kernel.nix
@@ -64,7 +64,7 @@ in
 
     boot.extraModulePackages = mkOption {
       default = [];
-      # !!! example = [pkgs.aufs pkgs.nvidia_x11];
+      # !!! example = [pkgs.nvidia_x11];
       description = "A list of additional packages supplying kernel modules.";
     };
 

--- a/modules/system/boot/stage-1-init.sh
+++ b/modules/system/boot/stage-1-init.sh
@@ -332,8 +332,8 @@ exec 3>&-
 udevadm control --exit || true
 
 # Kill any remaining processes, just to be sure we're not taking any
-# with us into stage 2.
-pkill -9 -v 1
+# with us into stage 2. unionfs-fuse mounts require the unionfs process.
+pkill -9 -v '(1|unionfs)'
 
 
 if test -n "$debug1mounts"; then fail; fi

--- a/modules/tasks/filesystems/unionfs-fuse.nix
+++ b/modules/tasks/filesystems/unionfs-fuse.nix
@@ -1,0 +1,19 @@
+{ config, pkgs, ... }:
+
+{
+  config = pkgs.lib.mkIf (pkgs.lib.any (fs: fs == "unionfs-fuse") config.boot.initrd.supportedFilesystems) {
+    boot.initrd.kernelModules = [ "fuse" ];
+
+    boot.initrd.extraUtilsCommands = ''
+      cp -v ${pkgs.fuse}/lib/libfuse* $out/lib
+      cp -v ${pkgs.unionfs-fuse}/bin/unionfs $out/bin
+    '';
+
+    boot.initrd.postDeviceCommands = ''
+        # Hacky!!! fuse hard-codes the path to mount
+        mkdir -p /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
+        ln -s $(which mount) /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
+        ln -s $(which umount) /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
+      '';
+  };
+}

--- a/modules/virtualisation/nova-image.nix
+++ b/modules/virtualisation/nova-image.nix
@@ -72,10 +72,6 @@ with pkgs.lib;
 
   boot.kernelParams = [ "console=ttyS0" ];
 
-  boot.initrd.kernelModules = [ "aufs" ];
-
-  boot.extraModulePackages = [ config.boot.kernelPackages.aufs ];
-
   boot.loader.grub.version = 2;
   boot.loader.grub.device = "/dev/vda";
   boot.loader.grub.timeout = 0;
@@ -83,8 +79,8 @@ with pkgs.lib;
   # Put /tmp and /var on /ephemeral0, which has a lot more space.
   # Unfortunately we can't do this with the `fileSystems' option
   # because it has no support for creating the source of a bind
-  # mount.  Also, "move" /nix to /ephemeral0 by layering an AUFS
-  # on top of it so we have a lot more space for Nix operations.
+  # mount.  Also, "move" /nix to /ephemeral0 by layering a unionfs-fuse
+  # mount on top of it so we have a lot more space for Nix operations.
   /*
   boot.initrd.postMountCommands =
     ''
@@ -96,9 +92,16 @@ with pkgs.lib;
       mkdir -m 755 -p $targetRoot/var
       mount --bind $targetRoot/ephemeral0/var $targetRoot/var
 
+      mkdir -p /unionfs-chroot/ro-nix
+      mount --rbind $targetRoot/nix /unionfs-chroot/ro-nix
+
+      mkdir -p /unionfs-chroot/rw-nix
       mkdir -m 755 -p $targetRoot/ephemeral0/nix
-      mount -t aufs -o dirs=$targetRoot/ephemeral0/nix=rw:$targetRoot/nix=rr none $targetRoot/nix
+      mount --rbind $targetRoot/ephemeral0/nix /unionfs-chroot/rw-nix
+      unionfs -o allow_other,cow,nonempty,chroot=/unionfs-chroot /rw-nix=RW:/ro-nix=RO $targetRoot/nix
     '';
+
+    boot.initrd.supportedFilesystems = [ "unionfs-fuse" ];
     */
 
   # Since Nova allows VNC access to instances, it's nice to start to

--- a/modules/virtualisation/qemu-vm.nix
+++ b/modules/virtualisation/qemu-vm.nix
@@ -252,16 +252,12 @@ in
   boot.initrd.availableKernelModules =
     [ "cifs" "nls_utf8" "hmac" "md4" "ecb" "des_generic" ];
 
-  # unionfs-fuse expects fuse to be loaded
-  boot.initrd.kernelModules = optional cfg.writableStore [ "fuse" ];
+  boot.initrd.supportedFilesystems = optional cfg.writableStore "unionfs-fuse";
 
   boot.initrd.extraUtilsCommands =
     ''
       # We need mke2fs in the initrd.
       cp ${pkgs.e2fsprogs}/sbin/mke2fs $out/bin
-    '' + optionalString cfg.writableStore ''
-      cp -v ${pkgs.fuse}/lib/libfuse* $out/lib
-      cp -v ${pkgs.unionfs-fuse}/bin/unionfs $out/bin
     '';
 
   boot.initrd.postDeviceCommands =
@@ -290,11 +286,6 @@ in
       mkdir -p $targetRoot/boot
       mount -o remount,ro $targetRoot/nix/store
       ${optionalString cfg.writableStore ''
-        # Hacky!!! fuse hard-codes the path to mount
-        mkdir -p /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
-        ln -s $(which mount) /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
-        ln -s $(which umount) /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-${pkgs.utillinux.name}/bin
-
         mkdir -p /unionfs-chroot$targetRoot
         mount --rbind $targetRoot /unionfs-chroot$targetRoot
 

--- a/modules/virtualisation/qemu-vm.nix
+++ b/modules/virtualisation/qemu-vm.nix
@@ -286,12 +286,12 @@ in
       mkdir -p $targetRoot/boot
       mount -o remount,ro $targetRoot/nix/store
       ${optionalString cfg.writableStore ''
-        mkdir -p /unionfs-chroot$targetRoot
-        mount --rbind $targetRoot /unionfs-chroot$targetRoot
+        mkdir -p /unionfs-chroot/ro-store
+        mount --rbind $targetRoot/nix/store /unionfs-chroot/ro-store
 
-        mkdir /unionfs-chroot/mnt-store-tmpfs
-        mount -t tmpfs -o "mode=755" none /unionfs-chroot/mnt-store-tmpfs
-        unionfs -o allow_other,cow,nonempty,chroot=/unionfs-chroot /mnt-store-tmpfs=RW:$targetRoot/nix/store=RO $targetRoot/nix/store
+        mkdir /unionfs-chroot/rw-store
+        mount -t tmpfs -o "mode=755" none /unionfs-chroot/rw-store
+        unionfs -o allow_other,cow,nonempty,chroot=/unionfs-chroot /rw-store=RW:/ro-store=RO $targetRoot/nix/store
       ''}
     '';
 


### PR DESCRIPTION
This branch replaces all uses of aufs with unionfs-fuse. This will allow the NixOS livecd and other features to work with an unpatched kernel (the aufs patch is quite invasive).

I've tested the changes to qemu-vm and iso-image. I've not tested the changes to amazon-image, but they are exactly analogous to qemu-vm and iso-image.

If there are no objections I will merge this soon.
