### PR TITLE
Parameterise the path to nixpkgs.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,12 @@
 { configuration ? import ./lib/from-env.nix "NIXOS_CONFIG" <nixos-config>
 , system ? builtins.currentSystem
+, nixpkgs ? <nixpkgs>
 }:
 
 let
 
   eval = import ./lib/eval-config.nix {
-    inherit system;
+    inherit system nixpkgs;
     modules = [ configuration ];
   };
 
@@ -13,13 +14,13 @@ let
 
   # This is for `nixos-rebuild build-vm'.
   vmConfig = (import ./lib/eval-config.nix {
-    inherit system;
+    inherit system nixpkgs;
     modules = [ configuration ./modules/virtualisation/qemu-vm.nix ];
   }).config;
 
   # This is for `nixos-rebuild build-vm-with-bootloader'.
   vmWithBootLoaderConfig = (import ./lib/eval-config.nix {
-    inherit system;
+    inherit system nixpkgs;
     modules =
       [ configuration
         ./modules/virtualisation/qemu-vm.nix

--- a/lib/eval-config.nix
+++ b/lib/eval-config.nix
@@ -7,6 +7,7 @@
 , baseModules ? import ../modules/module-list.nix
 , extraArgs ? {}
 , modules
+, nixpkgs ? <nixpkgs>
 }:
 
 let extraArgs_ = extraArgs; pkgs_ = pkgs; system_ = system; in
@@ -30,7 +31,7 @@ rec {
   extraArgs = extraArgs_ // {
     inherit pkgs modules baseModules;
     modulesPath = ../modules;
-    pkgs_i686 = import <nixpkgs> { system = "i686-linux"; };
+    pkgs_i686 = import nixpkgs { system = "i686-linux"; };
     utils = import ./utils.nix pkgs;
   };
 
@@ -47,7 +48,7 @@ rec {
   pkgs =
     if pkgs_ != null
     then pkgs_
-    else import <nixpkgs> (
+    else import nixpkgs (
       let
         system = if nixpkgsOptions.system != "" then nixpkgsOptions.system else system_;
         nixpkgsOptions = (import ./eval-config.nix {
@@ -55,7 +56,7 @@ rec {
           # For efficiency, leave out most NixOS modules; they don't
           # define nixpkgs.config, so it's pointless to evaluate them.
           baseModules = [ ../modules/misc/nixpkgs.nix ];
-          pkgs = import <nixpkgs> { system = system_; config = {}; };
+          pkgs = import nixpkgs { system = system_; config = {}; };
         }).optionDefinitions.nixpkgs;
       in
       {


### PR DESCRIPTION
This makes it possible to build several NixOS systems that use different
nixpkgs in the same nix-build invocation. Today, you can't do that since
the <nixpkgs> path reference is hard-coded in lib/eval-config.nix.
