### PR TITLE
Enable all firmware by default.

### DIFF
--- a/modules/hardware/all-firmware.nix
+++ b/modules/hardware/all-firmware.nix
@@ -7,7 +7,7 @@
   options = {
 
     hardware.enableAllFirmware = pkgs.lib.mkOption {
-      default = false;
+      default = true;
       type = pkgs.lib.types.bool;
       description = ''
         Turn on this option if you want to enable all the firmware shipped with Debian/Ubuntu.


### PR DESCRIPTION
Lots of hardware isn't supported out-of-the-box without this.
Much of that is networking, which makes new installs a pain. Those who want only free
firmware can disable this, but in the normal use case I think it makes more sense enabled.
