### PR TITLE
#88 dhcpcd: Add option to prevent dhcpcd from clobbering /etc/resolv.con...

### DIFF
--- a/modules/services/networking/dhcpcd.nix
+++ b/modules/services/networking/dhcpcd.nix
@@ -35,6 +35,9 @@ let
       # Ethernet cards used for bridging.  Likewise for vif* and tap*
       # (Xen) and virbr* and vnet* (libvirt).
       denyinterfaces ${toString ignoredInterfaces} peth* vif* tap* tun* virbr* vnet* vboxnet*
+      ${optionalString config.networking.dhcpcd.ignoreDNS ''
+        nohook resolv.conf
+      ''}
     '';
 
   # Hook for emitting ip-up/ip-down events.
@@ -82,6 +85,15 @@ in
          any of the shell glob patterns in this list. The purpose of
          this option is blacklist virtual interfaces such as those
          created by Xen, libvirt, LXC, etc.
+      '';
+    };
+
+    networking.dhcpcd.ignoreDNS = mkOption {
+      default = false;
+      description = ''
+        Configure dhcpcd so that it does not overwrite
+        /etc/resolv.conf. This option is useful if you wish to set
+        custom DNS servers in a GUI such as wicd.
       '';
     };
 


### PR DESCRIPTION
...f

Without this option enabled dhcpcd will insist on overwriting
/etc/resolv.conf even if has been modified manually, or by using a
program such as wicd.

After enabling this option I can restart dhcpcd and /etc/resolv.conf remains intact.
