### PR TITLE
Implementation: services.xserver.driSupport32Bits: Intel support via mesa (#92)

### DIFF
--- a/modules/services/x11/xserver.nix
+++ b/modules/services/x11/xserver.nix
@@ -225,7 +225,8 @@ in
         description = ''
           On 64-bit systems, whether to support Direct Rendering for
           32-bit applications (such as Wine).  This is currently only
-          supported for the <literal>nvidia</literal> driver.
+          supported for the <literal>nvidia</literal> driver and for
+          <literal>mesa</literal>.
         '';
       };
 
@@ -497,9 +498,12 @@ in
                 "ln -sf ${kernelPackages.nvidia_x11_legacy304} /run/opengl-driver"
               else if elem "ati_unfree" driverNames then
                 "ln -sf ${kernelPackages.ati_drivers_x11} /run/opengl-driver"
-              else if cfg.driSupport then
-                "ln -sf ${pkgs.mesa} /run/opengl-driver"
-              else ""
+              else
+                ''
+                  ${optionalString cfg.driSupport "ln -sf ${pkgs.mesa} /run/opengl-driver"}
+                  ${optionalString (pkgs.stdenv.system == "x86_64-linux" && cfg.driSupport32Bit)
+                    "ln -sf ${pkgs_i686.mesa} /run/opengl-driver-32"}
+                ''
             }
 
             ${cfg.displayManager.job.preStart}


### PR DESCRIPTION
This should fix #92.
