### PR TITLE
automatically import zpools and mount zfs filesystems

### DIFF
--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -61,7 +61,7 @@ in
         '';
     };
 
-    systemd.services."zpool-import"
+    systemd.services."zpool-import" = 
     { description = "Import zpools";
       after = [ "systemd-udev-settle.service" ];
       wantedBy = [ "multi-user.target" ]; 

--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -61,14 +61,25 @@ in
         '';
     };
 
-    systemd.services."zpool-import" = 
+    systemd.services."zpool-import" =
     { description = "Import zpools";
       after = [ "systemd-udev-settle.service" ];
-      wantedBy = [ "multi-user.target" ]; 
       serviceConfig =
       { Type = "oneshot";
         RemainAfterExit = true;
         ExecStart = "${kernel.zfs}/sbin/zpool import -f -a -d /dev";
+      };
+    };
+
+    systemd.services."zfs-mount" =
+    { description = "Mount zfs volumes";
+      after = [ "zpool-import.service" ];
+      wantedBy = [ "local-fs.target" ];
+      serviceConfig =
+      { Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${kernel.zfs}/sbin/zfs mount -a";
+        ExecStop = "${kernel.zfs}/sbin/zfs umount -a";
       };
     };
 

--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -61,6 +61,17 @@ in
         '';
     };
 
+    systemd.services."zpool-import"
+    { description = "Import zpools";
+      after = [ "systemd-udev-settle.service" ];
+      wantedBy = [ "multi-user.target" ]; 
+      serviceConfig =
+      { Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${kernel.zfs}/sbin/zpool import -f -a -d /dev";
+      };
+    };
+
     system.fsPackages = [ kernel.zfs ];                  # XXX: needed? zfs doesn't have a fsck
     environment.systemPackages = [ kernel.zfs ];
     services.udev.packages = [ kernel.zfs ];             # to hook zvol naming, etc. 


### PR DESCRIPTION
This is a first attempt at some zfs automation. 

`zpool-import.service` will attempt to import all of the (healthy) pools it finds from scanning `/dev`.
`zfs-mount.service`  will mount all of the zfs filesystems. 

The `zfs-mount.service` seems to be the right compromise between having to call `zfs mount` to mount a zfs filesystem (instead of just `mount`), and fitting in with the systemd `local-fs.target`

Tested in a initrd - luks setup with an ext4 `/`, and a zfs `/home`. 
