### PR TITLE
Fix Xorg-server on vmware inconjunction with

### DIFF
--- a/modules/services/x11/xserver.nix
+++ b/modules/services/x11/xserver.nix
@@ -192,8 +192,7 @@ in
       };
 
       videoDrivers = mkOption {
-        # !!! We'd like "nv" here, but it segfaults the X server.  Idem for
-        # "vmware".
+        # !!! We'd like "nv" here, but it segfaults the X server.
         default = [ "ati" "cirrus" "intel" "vesa" "vmware" ];
         example = [ "vesa" ];
         description = ''

--- a/modules/services/x11/xserver.nix
+++ b/modules/services/x11/xserver.nix
@@ -194,7 +194,7 @@ in
       videoDrivers = mkOption {
         # !!! We'd like "nv" here, but it segfaults the X server.  Idem for
         # "vmware".
-        default = [ "ati" "cirrus" "intel" "vesa" ];
+        default = [ "ati" "cirrus" "intel" "vesa" "vmware" ];
         example = [ "vesa" ];
         description = ''
           The names of the video drivers that the X server should


### PR DESCRIPTION
 fix to xf86videovmware[1].

Adds "vmware" to list of default options of
services.xerver.videoDrivers.

new default:
 [ "ati" "cirrus" "intel" "vesa" "vmware" ]

old default:
 [ "ati" "cirrus" "intel" "vesa" ]

[1] Pull request for xf86videovmware found at
https://github.com/NixOS/nixpkgs/pull/338.
