### PR TITLE
gst-ffmpeg -> gst-libav upstream rename.

### DIFF
--- a/modules/services/x11/desktop-managers/kde4.nix
+++ b/modules/services/x11/desktop-managers/kde4.nix
@@ -33,7 +33,7 @@ let
       pkgs.gst_all.gstPluginsGood
       pkgs.gst_all.gstPluginsUgly
       pkgs.gst_all.gstPluginsBad
-      pkgs.gst_all.gstFfmpeg # for mp3 playback
+      pkgs.gst_all.gstLibAV # for mp3 playback
       pkgs.gst_all.gstreamer # needed?
     ];
 


### PR DESCRIPTION
fixes problems introduced by https://github.com/NixOS/nixpkgs/pull/348
