### PR TITLE
systemd-logind: fix config file header: [Logind] => [Login]

### DIFF
--- a/modules/system/boot/systemd.nix
+++ b/modules/system/boot/systemd.nix
@@ -520,7 +520,7 @@ in
         }
         { source = pkgs.writeText "logind.conf"
             ''
-              [Logind]
+              [Login]
               ${config.services.logind.extraConfig}
             '';
           target = "systemd/logind.conf";


### PR DESCRIPTION
man logind.conf clearly states that the header is [Login](no).
Without this fix services.logind.extraConfig does not take effect
because logind ignores the invalidly named section.
