### PR TITLE
Add /run/nss to LD_LIBRARY_PATH

### DIFF
--- a/modules/config/nsswitch.nix
+++ b/modules/config/nsswitch.nix
@@ -22,6 +22,7 @@ let
         {
           inherit list;
           path = makeLibraryPath list;
+          dir = pkgs.symlinkJoin "nss-modules" (map (p: "${p}/lib") list);
         };
     };
 

--- a/modules/programs/bash/profile.sh
+++ b/modules/programs/bash/profile.sh
@@ -13,7 +13,7 @@ export __ETC_PROFILE_DONE=1
 
 # Initialise a bunch of environment variables.
 export LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive
-export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib # !!! only set if needed
+export LD_LIBRARY_PATH=/run/nss:/run/opengl-driver/lib:/run/opengl-driver-32/lib # !!! only set if needed
 export NIXPKGS_CONFIG=/etc/nix/nixpkgs-config.nix
 export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixpkgs=/etc/nixos/nixpkgs:nixos=/etc/nixos/nixos:nixos-config=/etc/nixos/configuration.nix:services=/etc/nixos/services
 export PAGER="less -R"

--- a/modules/system/activation/activation-script.nix
+++ b/modules/system/activation/activation-script.nix
@@ -150,6 +150,11 @@ in
         ${pkgs.utillinux}/bin/mount -o "remount,size=${config.boot.runSize}" none /run
       '';
 
+    system.activationScripts.nss =
+      ''
+        ln -sfn ${config.system.nssModules.dir} /run/nss
+      '';
+
   };
 
 }


### PR DESCRIPTION
This fixes issues with glibc-binaries (getent for example) that can't
find NSS modules that are not distributed with glibc.

See this discussion:
http://comments.gmane.org/gmane.linux.distributions.nixos/9940
