### PR TITLE
When enabling wacom put xsetwacom in PATH.

### DIFF
--- a/modules/services/x11/hardware/wacom.nix
+++ b/modules/services/x11/hardware/wacom.nix
@@ -60,6 +60,8 @@ in
 
   config = mkIf cfg.enable {
 
+    environment.systemPackages = [ pkgs.xf86_input_wacom ]; # provides xsetwacom
+
     services.xserver.modules = [ pkgs.xf86_input_wacom ];
 
     services.udev.packages = [ pkgs.xf86_input_wacom ];


### PR DESCRIPTION
I know that gnome/kde may have their own way to configure wacom tablets
