### PR TITLE
Udisks2 v2

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -82,6 +82,7 @@
   ./services/hardware/sane.nix
   ./services/hardware/udev.nix
   ./services/hardware/udisks.nix
+  ./services/hardware/udisks2.nix
   ./services/hardware/upower.nix
   ./services/logging/klogd.nix
   ./services/logging/logcheck.nix

--- a/modules/services/hardware/udisks2.nix
+++ b/modules/services/hardware/udisks2.nix
@@ -1,0 +1,53 @@
+# Udisks daemon.
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.udisks2 = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable Udisks, a DBus service that allows
+          applications to query and manipulate storage devices.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.udisks2.enable {
+
+    environment.systemPackages = [ pkgs.udisks2 ];
+
+    services.dbus.packages = [ pkgs.udisks2 ];
+
+    system.activationScripts.udisks2 =
+      ''
+        mkdir -m 0755 -p /var/lib/udisks2
+      '';
+
+    #services.udev.packages = [ pkgs.udisks2 ];
+    
+    systemd.services.udisks2 = {
+      description = "Udisks2 service";
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.freedesktop.UDisks2";
+        ExecStart = "${pkgs.udisks2}/lib/udisks2/udisksd --no-debug";
+      };
+    };
+  };
+
+}

--- a/modules/services/x11/desktop-managers/xfce.nix
+++ b/modules/services/x11/desktop-managers/xfce.nix
@@ -84,7 +84,7 @@ in
       '';
 
     # Enable helpful DBus services.
-    services.udisks.enable = true;
+    services.udisks2.enable = true;
     services.upower.enable = config.powerManagement.enable;
 
   };


### PR DESCRIPTION
This is new version of https://github.com/NixOS/nixos/pull/131, which adds udisks2 to the system. To summarize the knowledge:
- udisks2 will be used by gvfs after applying  https://github.com/NixOS/nixpkgs/pull/441. That should allow Thunar to mount/unmount removable media
- KDE has impure dependencies on udsisk1 so it should use existing udisk1 service and wait for better times
- It is possible to use gvfs with udisks2 disabled. gvfs just will not be able to see any removable media
