### PR TITLE
Step towards supporting multiple shells

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -37,6 +37,7 @@
   ./misc/passthru.nix
   ./misc/version.nix
   ./programs/bash/bash.nix
+  ./programs/zsh/zsh.nix
   ./programs/bash/command-not-found.nix
   ./programs/blcr.nix
   ./programs/info.nix

--- a/modules/programs/bash/bash.nix
+++ b/modules/programs/bash/bash.nix
@@ -1,38 +1,92 @@
 # This module defines global configuration for the Bash shell, in
 # particular /etc/bashrc and /etc/profile.
 
+# zsh.nix and bash.nix share a lot of code, thus update both!
+
+# specs:
+#
+# Usually there are two ways to run a shell:
+# - interactive mode (which should be a shiny colorful setup making it easy to work with)
+# - non interactive mode (run by scp rsync like tools or when you connect by ssh passing a command)
+#   Here its important to be compatible.
+#
+# Even though eg greycat #bash once told me systems should define not much in
+# global bashrc files NixOS is not very usable without at least having PATH
+# set. eg scp,rsync,... all would not work
+#
+# For this reason /etc/bashrc get's sourced always in some way and sets up a
+# basic environment.
+#
+# If you start another subshell eg by typing bash/zsh the env vars usually are
+# inherited (unless you use a login shell or env -i $SHELL).
+# For this reason nix keeps track about what it did by definining DID_NIX_* or __ETC_BASHRC_SOURCED
+# so that the same env vars don't get overpopulated even when switching shell.
+#
+# Because we want users be able to opt-out defining such a var or key
+# user's .bashrc is used to source that setup code. Users bashrc in turn
+# is setup by useradd/shadow due to /etc/skel
+# (TODO: shouldn't nix have a better way to update these files?)
+
+# A lot of code is shared with zsh.nix
+# This file contains both: bash specific and and any sh like specific setup
+# (such as shellAliases)
+
 { config, pkgs, ... }:
 
 with pkgs.lib;
 
 let
-
-  cfg = config.environment;
-
-  initBashCompletion = optionalString cfg.enableBashCompletion ''
-    # Check whether we're running a version of Bash that has support for
-    # programmable completion. If we do, enable all modules installed in
-    # the system (and user profile).
-    if shopt -q progcomp &>/dev/null; then
-      . "${pkgs.bashCompletion}/etc/profile.d/bash_completion.sh"
-      nullglobStatus=$(shopt -p nullglob)
-      shopt -s nullglob
-      for p in $NIX_PROFILES; do
-        for m in "$p/etc/bash_completion.d/"*; do
-          . $m
-        done
-      done
-      eval "$nullglobStatus"
-      unset nullglobStatus p m
-    fi
-  '';
+  cfg = config.environment.bash;
 
   shellAliases = concatStringsSep "\n" (
     mapAttrsFlatten (k: v: "alias ${k}='${v}'") cfg.shellAliases
   );
 
+  usedFeatures = builtins.listToAttrs (map (name: {inherit name; value = getAttr name cfg.availableFeatures; }) cfg.usedFeatures);
+
+  nixBashLib = pkgs.substituteAll {
+    src =  ./nix-bash-lib.sh;
+    code = concatStringsSep "\n" (catAttrs "lib" (attrValues usedFeatures));
+  };
+  nixBashLibPath = "/etc/bash/nix-bash-lib";
+
+  setupAll = ''
+    # system's default user's ~/.bashrc
+
+    declare -A DID_NIX_BASH_FEATURES
+    # you can opt out from features by declaring NIX_BASH_FEATURES as array and
+    # setting a key, eg declare -A NIX_BASH_FEATURES; DID_NIX_BASH_FEATURES["featureName"]=1
+    # same applies for DID_NIX_ENV_* vars
+    ''
+    + ( concatStrings (mapAttrsFlatten (name: attr:
+          let
+            featureName = if attr ? name then attr.name else name;
+          in
+          # interactive_code set's up interactive shell features
+          # rerun this code if you start a new zsh/bash subshell always
+            (optionalString (attr ? interactive_code) ''
+            # feature ${featureName}:
+            if [ -z "''${DID_NIX_BASH_FEATURES[${featureName}]}" ] && [ -n "$PS1" ]; then
+            ${attr.interactive_code}
+            DID_NIX_BASH_FEATURES["${featureName}"]=1
+            fi
+
+          '')
+          # env_code runs code setting up env vars.
+          # this should be done once (no matter which shell, thus export guard)
+          + (optionalString (attr ? env_code) ''
+            # feature ${featureName}:
+            if [ -z "''${DID_NIX_ENV_${featureName}}" ]; then
+            ${attr.env_code}
+            export DID_NIX_ENV_${featureName}=1
+            fi
+          '')
+          +"\n"
+        ) usedFeatures) );
+
   options = {
 
+    # TODO: move into bash namespace?
     environment.promptInit = mkOption {
       default = ''
         # Provide a nice prompt.
@@ -43,9 +97,9 @@ let
           PS1="\[\033]2;\h:\u:\w\007\]$PS1"
         fi
       '';
-      description = ''
-        Shell script code used to initialise the shell prompt.
-      '';
+      description = "
+        Script used to initialized sh/bash shell prompt.
+      ";
       type = with pkgs.lib.types; string;
     };
 
@@ -58,15 +112,7 @@ let
       type = with pkgs.lib.types; string;
     };
 
-    environment.interactiveShellInit = mkOption {
-      default = "";
-      example = ''export PATH=/godi/bin/:$PATH'';
-      description = ''
-        Shell script code called during interactive shell initialisation.
-      '';
-      type = with pkgs.lib.types; string;
-    };
-
+    # TODO: rename to environment.bash.enableCompletion ?
     environment.enableBashCompletion = mkOption {
       default = false;
       description = "Enable Bash completion for all interactive shells.";
@@ -85,6 +131,38 @@ let
       '';
     };
 
+    environment.bash.usedFeatures = mkOption {
+      default = attrNames cfg.availableFeatures;
+      description = ''
+        List bash which should be activated by default. Allow system administrators to provide a white list
+      '';
+    };
+
+    environment.bash.availableFeatures = mkOption {
+      type = types.attrsOf types.attrs;
+      description = ''
+        Provide a scalable way to provide bash features both admins and users
+        can extend, opt-out etc.
+
+        Remember that you have to implement each feature for each shell.
+
+        The default is to load everything by sourcing /etc/bash/setup-all
+        Users can opt-out by defining keys in the bash array before sourcing setup-all:
+        <code>
+        declare -A DID_NIX_BASH_FEATURES
+        DID_NIX_BASH_FEATURES["FEATURE_NAME"]=1
+        </code>
+      '';
+    };
+    environment.bash.shellAliases = mkOption {
+      type = types.attrs; # types.attrsOf types.stringOrPath;
+      default = {};
+      description = ''
+        bash specific shell aliases. global shell aliases are merged into this attrs.
+        See environment.shellAliases.
+      '';
+    };
+
   };
 
 in
@@ -97,7 +175,8 @@ in
         source = pkgs.substituteAll {
           src = ./profile.sh;
           wrapperDir = config.security.wrapperDir;
-          inherit (cfg) shellInit;
+          shellInit = config.environment.shellInit;
+          nixBashLib = nixBashLibPath;
         };
         target = "profile";
       }
@@ -105,10 +184,7 @@ in
       { # /etc/bashrc: executed every time a bash starts. Sources
         # /etc/profile to ensure that the system environment is
         # configured properly.
-        source = pkgs.substituteAll {
-          src = ./bashrc.sh;
-          inherit (cfg) interactiveShellInit;
-        };
+        source = ./bashrc.sh;
         target = "bashrc";
       }
 
@@ -116,24 +192,123 @@ in
         source = ./inputrc;
         target = "inputrc";
       }
+
+      { # some helper functions which are loaded as needed
+        source = nixBashLib;
+        target = "bash/nix-bash-lib";
+      }
+
+      { # default bash interactive setup which get's added to each user's
+        # .bashrc using skel/.bashrc, see below.
+        # This allows the user to opt-out and administrators to update
+        # the implementation
+        target = "bash/setup-all";
+        source = pkgs.writeText "bash-setup-all" setupAll;
+      }
+
+      # Be polite: suggest proper default setup - but let user opt-out.
+      { target = "skel/.bashrc";
+        source = pkgs.writeText "default-user-bashrc" ''
+          if [ -n "$PS1" ]; then
+            source /etc/bash/setup-all
+          fi
+        '';
+      }
+
+
     ];
 
-  environment.shellAliases =
-    { ls = "ls --color=tty";
-      ll = "ls -l";
-      l = "ls -alh";
-      which = "type -P";
-    };
+  environment.bash.shellAliases = config.shellAliases
+    // {which = "type -P"; };
 
-  environment.interactiveShellInit =
-    ''
+  environment.bash.availableFeatures = {
+
+    environment.zsh.shellAliases = config.environment.shellAliases;
+
+    other.interactive_code = ''
       # Check the window size after every command.
       shopt -s checkwinsize
-
-      ${cfg.promptInit}
-      ${initBashCompletion}
-      ${shellAliases}
     '';
+
+    promptInit.interactive_code = config.environment.promptInit;
+
+    # TODO: is it a good idea to always provide pkgs.bashCompletion ?
+    # how does it compare with completion provided by the bash sample code ?
+    completion = {
+      interactive_code = ''
+        if ${if config.environment.enableBashCompletion then "true" else "false" }; then
+          source ${nixBashLibPath}
+          [ -e /etc/bash/completion ] && . /etc/bash/completion
+          nix_foreach_profile nix_add_profile_completion
+        fi
+      '';
+      lib = ''
+        # completion support you can opt out by setting NIX_COMPL_SCRIPT_SOURCED[ALL]
+        # to either the basename of a completion script or ALL.
+
+        declare -A NIX_COMPL_SCRIPT_SOURCED
+
+        # potential problems (-rev 20179)
+        #  - It doesn't support filenames with spaces.
+        #  - It inserts a space after the filename when tab-completing in an
+        #    "svn" command.
+        #  - Many people find it annoying that tab-completion on commands like
+        #    "tar" only matches filenames with the "right" extension.
+        #  - Lluís reported bash apparently crashing on some tab completions.
+        # comment: Does this apply to complete.gnu-longopt or also to bash_completion?
+        NIX_COMPL_SCRIPT_SOURCED[complete.gnu-longopt]=1
+
+
+        if shopt -q progcomp &>/dev/null; then
+          # bash supports completion:
+          nix_add_profile_completion(){
+            local profile="$1"
+
+            # origin: bash_completion, slightly adopted
+            # source script only once - allow user to use NIX_COMPL_SCRIPT_SOURCED to
+            # opt out from bad scripts. If a user wants to reload all he can clear
+            # NIX_COMPL_SCRIPT_SOURCED
+
+            local nullglobStatus=$(shopt -p nullglob)
+            shopt -s nullglob
+            for s in "$profile"/etc/bash_completion.d/*; do
+              local base="''${s/*\//}"
+              [[
+                -z "''${NIX_COMPL_SCRIPT_SOURCED[$base]}" &&
+                -z "''${NIX_COMPL_SCRIPT_SOURCED[ALL]}"
+              ]] && { . "$s"; NIX_COMPL_SCRIPT_SOURCED[$base]=1; }
+
+            done
+            eval "$nullglobStatus"
+          }
+        else
+          nix_add_profile_completion(){ :; }
+        fi
+      '';
+    };
+
+    xmlCatalogFileSupport = {
+      name = "xml_catalog_file_support";
+      env_code = ''
+        source ${nixBashLibPath}
+        # not sure how well this scales - this maybe refactored in the future
+        # alternative would be introducing /etc/xml/catalog which might be more impure
+        nix_foreach_profile nix_add_xml_catalog
+      '';
+      lib = ''
+        nix_add_xml_catalog(){
+          # $1 = profile
+          for kind in dtd xsl; do
+            if [ -d $1/xml/$kind ]; then
+              for j in $(find $1/xml/$kind -name catalog.xml); do
+                nix_export_suffix XML_CATALOG_FILES "$j" ' '
+              done
+            fi
+          done
+        }
+      '';
+    };
+  };
 
   system.build.binsh = pkgs.bashInteractive;
 
@@ -142,9 +317,10 @@ in
       # Create the required /bin/sh symlink; otherwise lots of things
       # (notably the system() function) won't work.
       mkdir -m 0755 -p /bin
-      ln -sfn "${cfg.binsh}" /bin/.sh.tmp
+      ln -sfn "${config.environment.binsh}" /bin/.sh.tmp
       mv /bin/.sh.tmp /bin/sh # atomically replace /bin/sh
     '';
 
-  environment.pathsToLink = optional cfg.enableBashCompletion "/etc/bash_completion.d";
+  # always link bash_completion.d, user's may want to opt-in.
+  environment.pathsToLink = ["/etc/bash_completion.d"];
 }

--- a/modules/programs/bash/bashrc.sh
+++ b/modules/programs/bash/bashrc.sh
@@ -12,8 +12,3 @@ __ETC_BASHRC_SOURCED=1
 if [ -z "$__ETC_PROFILE_DONE" ]; then
     . /etc/profile
 fi
-
-# We are not always an interactive shell.
-if [ -z "$PS1" ]; then return; fi
-
-@interactiveShellInit@

--- a/modules/programs/bash/command-not-found.nix
+++ b/modules/programs/bash/command-not-found.nix
@@ -3,6 +3,8 @@
 # SQLite database that maps program names to Nix package names (e.g.,
 # "pdflatex" is mapped to "tetex").
 
+# TODO: implement for ZSH?
+
 { config, pkgs, ... }:
 
 with pkgs.lib;
@@ -23,8 +25,7 @@ in
 
 {
 
-  environment.interactiveShellInit =
-    ''
+  environment.bash.availableFeatures.command_not_found.interactive_code = ''
       # This function is called whenever a command is not found.
       command_not_found_handle() {
         local p=/run/current-system/sw/bin/command-not-found

--- a/modules/programs/bash/nix-bash-lib.sh
+++ b/modules/programs/bash/nix-bash-lib.sh
@@ -1,0 +1,60 @@
+if [ "$(type -p nix_export_prefix 2>/dev/null)" == "function" ]; then return; fi
+
+# define some helper functions if not defined yet:
+
+# helper function prefixing - appending a item to an env var
+# eg: nix_export_a PATH NEW --prefix|--suffix
+nix_export_prefix(){
+  # local var="$1"
+  # local value="$2"
+  # local sep="$3"
+  export "$1=${2}${!1:+${3:-:}}${!1}"
+}
+nix_export_suffix(){
+  export "$1=${!1}${!1:+${3:-:}}${2}"
+}
+
+nix_foreach_profile(){
+  local cmd="$1"
+  for p in $NIX_PROFILES; do $cmd "$p"; done
+}
+
+# add env vars for different profiles. Define a function so that user can reuse this code
+# I'm not sure wether this global file should know about ALSA, GStreamer, ..
+# specific stuff - but everything else would be much more complicated?
+nix_add_profile_vars(){
+    local export=$1
+    local i="$2"
+
+    # We have to care not leaving an empty PATH element, because that means '.' to Linux
+    $export PATH "$i/bin:$i/sbin:$i/lib/kde4/libexec"
+    $export INFOPATH "$i/info:$i/share/info"
+    $export PKG_CONFIG_PATH "$i/lib/pkgconfig"
+
+    # terminfo and reset TERM with new TERMINFO available
+    if [ -d $i/share/terminfo ]; then
+      $export TERMINFO_DIRS $i/share/terminfo
+      TERM=$TERM
+    fi
+
+    $export PERL5LIB "$i/lib/perl5/site_perl"
+
+    # ALSA plugins
+    $export ALSA_PLUGIN_DIRS "$i/lib/alsa-lib"
+
+    # GStreamer.
+    $export GST_PLUGIN_PATH "$i/lib/gstreamer-0.10"
+
+    # KDE/Gnome stuff.
+    $export KDEDIRS "$i"
+    $export STRIGI_PLUGIN_PATH "$i/lib/strigi/"
+    $export QT_PLUGIN_PATH "$i/lib/qt4/plugins:$i/lib/kde4/plugins"
+    $export QTWEBKIT_PLUGIN_PATH "$i/lib/mozilla/plugins/"
+    $export XDG_CONFIG_DIRS "$i/etc/xdg"
+    $export XDG_DATA_DIRS "$i/share"
+
+    # mozilla plugins
+    $export MOZ_PLUGIN_PATH $i/lib/mozilla/plugins
+}
+
+@code@

--- a/modules/programs/shell.nix
+++ b/modules/programs/shell.nix
@@ -21,5 +21,12 @@ with pkgs.lib;
   };
 
   config = {
+    environment.shellAliases =
+      { ls = "ls --color=tty";
+        ll = "ls -l";
+        l = "ls -alh";
+        # see bash.nix, type -P does not exist for zsh
+        # which = "type -P";
+      };
   };
 }

--- a/modules/programs/zsh/nix-zsh-lib.sh
+++ b/modules/programs/zsh/nix-zsh-lib.sh
@@ -1,0 +1,63 @@
+# ZSH file
+
+if whence -f nix_export_prefix &> /dev/null; then return ; fi
+
+# define some helper functions if not defined yet:
+
+# helper function prefixing - appending a item to an env var
+# eg: nix_export_a PATH NEW --prefix|--suffix
+nix_export_prefix(){
+  # local var="$1"
+  # local value="$2"
+  # local sep="$3"
+  export "$1=${2}${(P)1:+$3:-:}${(P)1}"
+}
+nix_export_suffix(){
+  export "$1=${(P)1}${(P)1:+${3:-:}}${2}"
+}
+nix_foreach_profile(){
+  local cmd="$1"
+  for p in ${=NIX_PROFILES}; do ${=cmd} "$p"; done
+}
+
+
+
+# add env vars for different profiles. Define a function so that user can reuse this code
+# I'm not sure wether this global file should know about ALSA, GStreamer, ..
+# specific stuff - but everything else would be much more complicated?
+nix_add_profile_vars(){
+    local export=$1
+    local i="$2"
+
+    # We have to care not leaving an empty PATH element, because that means '.' to Linux
+    $export PATH "$i/bin:$i/sbin:$i/lib/kde4/libexec"
+    $export INFOPATH "$i/info:$i/share/info"
+    $export PKG_CONFIG_PATH "$i/lib/pkgconfig"
+
+    # terminfo and reset TERM with new TERMINFO available
+    if [ -d $i/share/terminfo ]; then
+      $export TERMINFO_DIRS $i/share/terminfo
+      TERM=$TERM
+    fi
+
+    $export PERL5LIB "$i/lib/perl5/site_perl"
+
+    # ALSA plugins
+    $export ALSA_PLUGIN_DIRS "$i/lib/alsa-lib"
+
+    # GStreamer.
+    $export GST_PLUGIN_PATH "$i/lib/gstreamer-0.10"
+
+    # KDE/Gnome stuff.
+    $export KDEDIRS "$i"
+    $export STRIGI_PLUGIN_PATH "$i/lib/strigi/"
+    $export QT_PLUGIN_PATH "$i/lib/qt4/plugins:$i/lib/kde4/plugins"
+    $export QTWEBKIT_PLUGIN_PATH "$i/lib/mozilla/plugins/"
+    $export XDG_CONFIG_DIRS "$i/etc/xdg"
+    $export XDG_DATA_DIRS "$i/share"
+
+    # mozilla plugins
+    $export MOZ_PLUGIN_PATH $i/lib/mozilla/plugins
+}
+
+@code@

--- a/modules/programs/zsh/zsh.nix
+++ b/modules/programs/zsh/zsh.nix
@@ -1,0 +1,246 @@
+# This module defines global configuration for the zsh shell, in
+# particular /etc/zshenv
+
+# zsh.nix and bash.nix share a lot of code, thus update both!
+
+# Please read comments at bash.nix, a lot of code is shared
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+
+  cfg = config.environment.zsh;
+
+  shellAliases = concatStringsSep "\n" (
+    mapAttrsFlatten (k: v: "alias ${k}='${v}'") cfg.shellAliases
+  );
+
+  usedFeatures = builtins.listToAttrs (map (name: {inherit name; value = getAttr name cfg.availableFeatures; }) cfg.usedFeatures);
+
+  # TODO: support zsh's autoload feature? (and precompilation!?)
+  nixZshLib = pkgs.substituteAll {
+    src =  ./nix-zsh-lib.sh;
+    code = concatStringsSep "\n" (catAttrs "lib" (attrValues usedFeatures));
+  };
+  nixZshLibPath = "/etc/zsh/nix-zsh-lib";
+
+  setupAll = ''
+    # system's default user's ~/.zshrc
+
+    declare -A DID_NIX_ZSH_FEATURES
+    # you can opt out from features by declaring NIX_ZSH_FEATURES as array and
+    # setting a key, eg declare -A NIX_ZSH_FEATURES; DID_NIX_ZSH_FEATURES["featureName"]=1
+    # same applies for DID_NIX_ENV_* vars
+    ''
+    + ( concatStrings (mapAttrsFlatten (name: attr:
+          let
+            featureName = if attr ? name then attr.name else name;
+          in
+          # interactive_code set's up interactive shell features
+          # rerun this code if you start a new zsh/bash subshell always
+            (optionalString (attr ? interactive_code) ''
+            # feature ${featureName}:
+            if [ -z "''${DID_NIX_ZSH_FEATURES[${featureName}]}" ] && [ -n "$PS1" ]; then
+            ${attr.interactive_code}
+            DID_NIX_ZSH_FEATURES["${featureName}"]=1
+            fi
+
+          '')
+          # env_code runs code setting up env vars.
+          # this should be done once (no matter which shell, thus export guard
+          + (optionalString (attr ? env_code) ''
+            # feature ${featureName}:
+            if [ -z "''${DID_NIX_ENV_${featureName}}" ]; then
+            ${attr.env_code}
+            export DID_NIX_ENV_${featureName}=1
+            fi
+          '')
+          +"\n"
+        ) usedFeatures) );
+
+  options = {
+
+    environment.zsh.enable = mkOption {
+      default = false;
+      example = true;
+      description = ''
+        enable zsh support (eg provide /etc/zshenv /etc/skel/.zshrc, ..
+      '';
+    };
+
+    environment.zsh.promptInit =  mkOption {
+      default = "
+        PS1=\"%n@%M \\\$(basename \\\"\\\${PWD}\\\") %? %#\"
+
+        RPS2=\"%?\\\${fg[black]}\\\${PWD} %m\"
+      ";
+      description = "
+        Script used to initialized zsh shell prompt.
+      ";
+      type = with pkgs.lib.types; string;
+    };
+
+    environment.zsh.shellInit = mkOption {
+      default = "";
+      example = ''export PATH=/godi/bin/:$PATH'';
+      description = "
+        Script used to initialized user shell environments.
+      ";
+      type = with pkgs.lib.types; string;
+    };
+
+    environment.zsh.enableCompletion = mkOption {
+      default = true;
+      description = "Enable zsh-completion for all interactive shells.";
+      type = with pkgs.lib.types; bool;
+    };
+
+    environment.zsh.usedFeatures = mkOption {
+      default = attrNames cfg.availableFeatures;
+      type = types.listOf types.string;
+      description = ''
+        List zsh features which should be activated by default. Allow system
+        administrators to provide a white list
+      '';
+    };
+
+    environment.zsh.availableFeatures = mkOption {
+      default = {};
+      type = types.attrsOf types.attrs;
+      description = ''
+        Provide a scalable way to provide zsh features both admins and users
+        can extend, opt-out etc.
+
+        Remember that you have to implement each feature for each shell.
+
+        The default is to load everything by sourcing /etc/zsh/setup-all
+        Users can opt-out by defining keys in the zsh array before sourcing setup-all:
+        <code>
+        declare -A DID_NIX_ZSH_FEATURES
+        DID_NIX_ZSH_FEATURES["FEATURE_NAME"]=1
+        </code>
+      '';
+    };
+
+    environment.zsh.shellAliases = mkOption {
+      type = types.attrs; # types.attrsOf types.stringOrPath;
+      default = {};
+      description = ''
+        zsh specific shell aliases. global shell aliases are merged into this attrs.
+        See environment.shellAliases.
+      '';
+    };
+
+
+  };
+
+in
+
+{
+  inherit options;
+
+  config = mkIf config.environment.zsh.enable {
+    environment.etc =
+      [ 
+
+        { # login and non login shells:
+          source = pkgs.substituteAll {
+            src = ./zshenv;
+            wrapperDir = config.security.wrapperDir;
+            shellInit = config.environment.shellInit;
+            nixZshLib = nixZshLibPath;
+          };
+          target = "zshenv";
+        }
+
+        { # some helper functions which are loaded as needed
+          source = nixZshLib;
+          target = "zsh/nix-zsh-lib";
+        }
+
+        { # default zsh interactive setup which get's added to each user's
+          # .zshrc using skel/.zshrc, see below.
+          # This allows the user to opt-out and administrators to update
+          # the implementation
+          target = "zsh/setup-all";
+          source = pkgs.writeText "zsh-setup-all" setupAll;
+        }
+
+        # Be polite: suggest proper default setup - but let user opt-out.
+        { target = "skel/.zshrc";
+          source = pkgs.writeText "default-user-zshrc" ''
+            if [ -n "$PS1" ]; then
+              source /etc/zsh/setup-all
+            fi
+          '';
+        }
+
+      ];
+
+
+    environment.systemPackages = [ pkgs.zsh ];
+
+    environment.zsh.shellAliases = config.environment.shellAliases;
+
+    environment.zsh.availableFeatures = {
+
+      aliases.interactive_code = shellAliases;
+
+      other.interactive_code = ''
+        # Check the window size after every command.
+        setopt CORRECT
+        setopt hist_ignore_dups
+        setopt PROMPT_SUBST
+
+        # beeping is annoying
+        setopt NO_HIST_BEEP
+        setopt NO_BEEP
+
+        # history setup - maybe 20000 lines is much
+        setopt share_history
+        HISTFILE=~/.histfile
+        HISTSIZE=20000
+        SAVEHIST=20000
+      '';
+
+      promptInit.interactive_code = config.environment.zsh.promptInit;
+
+      # TODO: is it a good idea to always provide pkgs.zshCompletion ?
+      # how does it compare with completion provided by the zshrc sample code ?
+      completion.interactive_code = ''
+          if ${if config.environment.zsh.enableCompletion then "true" else "false" }; then
+          # setup completion:
+          autoload -Uz compinit; compinit
+          # nix-env always uses pager :( TODO: make it behave like git diff:
+          # don't show pager when using a pipe
+          compdef _gnu_generic nix-{store,instantiate,channel,env,build}
+          PATH=$PATH:@gnugrep@/bin compinit
+          fi
+        '';
+
+      xmlCatalogFileSupport = {
+        env_code = ''
+          source ${nixZshLibPath}
+          # not sure how well this scales - this maybe refactored in the future
+          # alternative would be introducing /etc/xml/catalog which might be more impure
+          nix_foreach_profile nix_add_xml_catalog
+        '';
+        lib = ''
+          nix_add_xml_catalog(){
+            # $1 = profile
+            for kind in dtd xsl; do
+              if [ -d $1/xml/$kind ]; then
+                for j in $(find $1/xml/$kind -name catalog.xml); do
+                  nix_export_suffix XML_CATALOG_FILES "$j" ' '
+                done
+              fi
+            done
+          }
+        '';
+      };
+    };
+
+  };
+}

--- a/modules/programs/zsh/zshenv
+++ b/modules/programs/zsh/zshenv
@@ -1,14 +1,10 @@
-# /etc/profile: DO NOT EDIT -- this file has been generated automatically.
-
-# This file is read for (interactive) login shells.  Any
-# initialisation specific to interactive shells should be put in
-# /etc/bashrc, which is sourced from here.
+# /etc/zsh: DO NOT EDIT -- this file has been generated automatically.
 
 # Only execute this file once per shell.
 if [ -n "$__ETC_PROFILE_SOURCED" ]; then return; fi
 __ETC_PROFILE_SOURCED=1
 
-source @nixBashLib@
+source @nixZshLib@
 
 # Prevent this file from being sourced by interactive non-login child shells.
 if [ -n "$__ETC_PROFILE_DONE" ]; then return; fi
@@ -21,7 +17,6 @@ export NIXPKGS_CONFIG=/etc/nix/nixpkgs-config.nix
 export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixpkgs=/etc/nixos/nixpkgs:nixos=/etc/nixos/nixos:nixos-config=/etc/nixos/configuration.nix:services=/etc/nixos/services
 export PAGER="less -R"
 export EDITOR=nano
-export LOCATE_PATH=/var/cache/locatedb
 
 # Include the various profiles in the appropriate environment variables.
 export NIX_USER_PROFILE_DIR=/nix/var/nix/profiles/per-user/$USER
@@ -85,12 +80,3 @@ if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
 fi
 
 @shellInit@
-
-# Read system-wide modifications.
-if test -f /etc/profile.local; then
-    . /etc/profile.local
-fi
-
-if [ -n "${BASH_VERSION:-}" ]; then
-    . /etc/bashrc
-fi


### PR DESCRIPTION
Please note that I'd like to push this for discussion - it doesn't mean you have to merge it right now.

bash setup changes:
- new option environment.bashFeatures modularizing bash setup
  implementations based on previous code: prompt, completion, aliases, other
  -> See examples below
- provide /etc/bash/setup-all shell scripts setting those features up
  You can opt out by defining keys in DID_NIX_BASH_FEATURES, use declare -A
  first (see comment)
- provide /etc/skel/.bashrc which by default sources setup-all
  This way users can opt-out. Mind that I wrote a [shadow patch](https://github.com/NixOS/nixpkgs/pull/459) so that user-add
  creates ~/.bashrc as file, not as symlink
- support XML_CATALOG_FILES, so that you can use xmllint like tools without
  having them download dts easily
- introduce nix-bash-lib which provides some helper functions.
  It is sourced as needed.
- export __ETC_PROFILE_DONE, so that profile isn't setup twice

zsh:
  implement the very same.
  Please note that the zshrc hack found in nixpkgs is obsolete then.

Thus a typical .bashrc/ .zshrc of a user looks like this after this patch:

```
# opt-out from the completion feature:

declare -A DID_NIX_BASH_FEATURES
DID_NIX_BASH_FEATURES["completion"]=1

# but load everything else the system administrator thinks is useful on
# this machine:
source /etc/bash/setup-all

# custom setup of the user
....
```

Example features zsh:
Note that interactive_code is only loaded for interactive shells whereas
env_code is loaded always

```
zsh.availableFeatures = {
  # simple xpath like navigation for the filesystem. Eg open /etc/nixos/configuration.nix by
  # E /enc
  pathSelector.interactive_code = let ps = "${pkgs.misc.pathSelector}/bin/path-selector"; in ''
    autoload -Uz _path_selector
    bindkey '^g' _path_selector
    zle -N _path_selector
    fpath=(${pkgs.misc.pathSelector}/fpath $fpath)

    C()   { cd       $(${ps} "$@"); }
    E()   { $EDITOR  $(${ps} "$@"); }
    MDC() { mdc      $(${ps} "$@"); }
    alias F=${ps}'';

  # setup vi keybindings for zsh, but keep useful mappings like ctrl-a ctrl-e (move to start/end of line)
  vi_setup.interactive_code = ''
    # vi keys
    bindkey -v
    bindkey "^a" beginning-of-line
    bindkey "^e" end-of-line
    bindkey "^p" up-line-or-history
    bindkey "^r" history-incremental-search-backward
  '';

  # provide a function which can be used to install Vim plugin vim-addon-manager
  vam.env_code = ''
    vim-install-vam(){
    mkdir -p ~/.vim/vim-addons \
    && git clone --depth=1 git://github.com/MarcWeber/vim-addon-manager.git ~/.vim/vim-addons/vim-addon-manager \
    && cat >> ~/.vimrc << EOF
    set nocompatible
    filetype indent plugin on | syn on
    fun ActivateAddons()
      let g:vim_addon_manager = {}
      let g:vim_addon_manager.log_to_buf =1
      set runtimepath+=~/.vim/vim-addons/vim-addon-manager
      call vam#ActivateAddons([])
    endf
    call ActivateAddons()
    " experimental: run after gui has been started [3]
    " option1:  au VimEnter * call Activate()
    " option2:  au GUIEnter * call Activate()
    EOF
    }
    '';
};
```

TODO: provide other implementations (fish etc)

Signed-off-by: Marc Weber marco-oweber@gmx.de
