### PR TITLE
udev rule to populate /dev/vboxusb

### DIFF
--- a/modules/programs/virtualbox.nix
+++ b/modules/programs/virtualbox.nix
@@ -15,8 +15,10 @@ let virtualbox = config.boot.kernelPackages.virtualbox; in
     ''
       KERNEL=="vboxdrv",    OWNER="root", GROUP="vboxusers", MODE="0660", TAG+="systemd"
       KERNEL=="vboxnetctl", OWNER="root", GROUP="root",      MODE="0600", TAG+="systemd"
-      SUBSYSTEM=="usb_device", ATTR{devnum}=="?*", ATTR{busnum}=="?*",SYMLINK+="vboxusb/$attr{busnum}/$attr{devnum}", GROUP="vboxusers"
-      SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{devnum}=="?*", ATTR{busnum}=="?*",SYMLINK+="vboxusb/$attr{busnum}/$attr{devnum}", GROUP="vboxusers"
+      SUBSYSTEM=="usb_device", ACTION=="add", RUN+="${virtualbox}/libexec/virtualbox/VBoxCreateUSBNode.sh $major $minor $attr{bDeviceClass}"
+      SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", RUN+="${virtualbox}/libexec/virtualbox/VBoxCreateUSBNode.sh $major $minor $attr{bDeviceClass}"
+      SUBSYSTEM=="usb_device", ACTION=="remove", RUN+="${virtualbox}/libexec/virtualbox/VBoxCreateUSBNode.sh --remove $major $minor"
+      SUBSYSTEM=="usb", ACTION=="remove", ENV{DEVTYPE}=="usb_device", RUN+="${virtualbox}/libexec/virtualbox/VBoxCreateUSBNode.sh --remove $major $minor"
     '';
 
   # Since we lack the right setuid binaries, set up a host-only network by default.

--- a/modules/programs/virtualbox.nix
+++ b/modules/programs/virtualbox.nix
@@ -15,6 +15,8 @@ let virtualbox = config.boot.kernelPackages.virtualbox; in
     ''
       KERNEL=="vboxdrv",    OWNER="root", GROUP="vboxusers", MODE="0660", TAG+="systemd"
       KERNEL=="vboxnetctl", OWNER="root", GROUP="root",      MODE="0600", TAG+="systemd"
+      SUBSYSTEM=="usb_device", ATTR{devnum}=="?*", ATTR{busnum}=="?*",SYMLINK+="vboxusb/$attr{busnum}/$attr{devnum}", GROUP="vboxusers"
+      SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{devnum}=="?*", ATTR{busnum}=="?*",SYMLINK+="vboxusb/$attr{busnum}/$attr{devnum}", GROUP="vboxusers"
     '';
 
   # Since we lack the right setuid binaries, set up a host-only network by default.


### PR DESCRIPTION
This fixes NixOS/nixpkgs#457. After Linux 3.2(?), /proc/bus/usb (and usbfs
(or usbdevfs?)) went away, leaving virtualbox no way to determine what USB
devices were connected to the system. The solution was to add some virtualbox
specific udev rules to populate /dev/vboxusb with what was in /proc/bus/usb
before.

  This patch adds those rules.
