### PR TITLE
Make bitlbee work in systemd

### DIFF
--- a/modules/services/networking/bitlbee.nix
+++ b/modules/services/networking/bitlbee.nix
@@ -81,7 +81,7 @@ in
 
 	exec =
 	  ''
-	    ${pkgs.bitlbee}/sbin/bitlbee -F -p ${toString portNumber} \
+	    ${pkgs.bitlbee}/sbin/bitlbee -n -F -p ${toString portNumber} \
 	      -i ${interface} -u bitlbee
 	  '';
       };


### PR DESCRIPTION
Turns off bitlbee forking itself into the background.
