### PR TITLE
ssmtp: Add AuthUser and AuthPass options.

### DIFF
--- a/modules/programs/ssmtp.nix
+++ b/modules/programs/ssmtp.nix
@@ -77,7 +77,7 @@ let
         default = "
           Password used for SMTP auth.
         ";
-      }
+      };
 
     };
 

--- a/modules/programs/ssmtp.nix
+++ b/modules/programs/ssmtp.nix
@@ -63,6 +63,22 @@ let
         ";
       };
 
+      authUser = mkOption {
+        default = "";
+        example = "foo@example.org";
+        description = "
+          Username used for SMTP auth. Leave blank to disable.
+        ";
+      };
+
+      authPass = mkOption {
+        default = "";
+        example = "correctHorseBatteryStaple";
+        default = "
+          Password used for SMTP auth.
+        ";
+      }
+
     };
 
   };
@@ -82,6 +98,8 @@ mkIf cfg.directDelivery {
           UseTLS=${if cfg.useTLS then "YES" else "NO"}
           UseSTARTTLS=${if cfg.useSTARTTLS then "YES" else "NO"}
           #Debug=YES
+          ${if cfg.authUser != "" then "AuthUser=${cfg.authUser}" else ""}
+          ${if cfg.authPass != "" then "AuthPass=${cfg.authPass}" else ""}
         '';
         target = "ssmtp/ssmtp.conf";
       }


### PR DESCRIPTION
Add AuthUser and AuthPass options for ssmtp. 

These can be used to enable all users to send mail via a simple SMTP server like smtp.gmail.com.
