### PR TITLE
Static nameservers should have precedence

### DIFF
--- a/modules/tasks/network-interfaces.nix
+++ b/modules/tasks/network-interfaces.nix
@@ -277,7 +277,7 @@ in
             script =
               ''
                 # Set the static DNS configuration, if given.
-                cat | ${pkgs.openresolv}/sbin/resolvconf -a static <<EOF
+                cat | ${pkgs.openresolv}/sbin/resolvconf -m -1 -a static <<EOF
                 ${optionalString (cfg.nameservers != [] && cfg.domain != "") ''
                   domain ${cfg.domain}
                 ''}


### PR DESCRIPTION
Here is a fix for priorites for static nameservers. 

Default priority for resolvconf is 0, i think static nameservers should have -1, to always make then stand before dynamic ones. This way attacker or bogus network having control over dhcp server(or ND in ipv6 world) would not be able to overwrite our static dns servers.
