### PR TITLE
restart networkmanager on suspend resume

### DIFF
--- a/modules/services/networking/networkmanager.nix
+++ b/modules/services/networking/networkmanager.nix
@@ -124,6 +124,10 @@ in {
       wireless.enable = false;
     };
 
+    powerManagement.resumeCommands = ''
+      systemctl restart NetworkManager
+    '';
+
     security.polkit.permissions = polkitConf;
 
     services.dbus.packages = cfg.packages;


### PR DESCRIPTION
NetworkManager doesn't work after a suspend, but restarting it helps. I'd just do that from NixOS.
