### PR TITLE
nixos-install: fix error message consistency

### DIFF
--- a/modules/installer/tools/nixos-install.sh
+++ b/modules/installer/tools/nixos-install.sh
@@ -30,7 +30,7 @@ if ! grep -F -q " $mountPoint " /proc/mounts; then
 fi
 
 if ! test -e "$mountPoint/$NIXOS_CONFIG"; then
-    echo "configuration file $NIXOS_CONFIG doesn't exist"
+    echo "configuration file $mountPoint/$NIXOS_CONFIG doesn't exist"
     exit 1
 fi
 


### PR DESCRIPTION
The test is for path A but the error message says path B. Fix it.
