### PR TITLE
fix wacom hotplug and all Intuos 5 issues

### DIFF
--- a/modules/services/x11/hardware/wacom.nix
+++ b/modules/services/x11/hardware/wacom.nix
@@ -16,41 +16,15 @@ in
 
       enable = mkOption {
         default = false;
-        description = "Whether to enable the Wacom touchscreen/digitizer/tablet.";
-      };
+        description = ''
+          Whether to enable the Wacom touchscreen/digitizer/tablet.
+          If you ever have any issues such as, try switching to terminal (ctrl-alt-F1) and back
+          which will make Xorg reconfigure the device ?
 
-      device = mkOption {
-        default = null;
-        example = "/dev/ttyS0";
-        description = "Device to use. Set to null for autodetect (think USB tablet).";
-      };
-
-      forceDeviceType = mkOption {
-        default = null;
-        example = "ISDV4";
-        description = "Some models (think touchscreen) require the device type to be specified. Set to null for autodetect (think USB tablet).";
-      };
-
-      stylusExtraConfig = mkOption {
-        default = "";
-        example = ''
-            Option "Button1" "2"
-          '';
-        description = "Lines to be added to Wacom_stylus InputDevice section.";
-      };
-
-      eraserExtraConfig = mkOption {
-        default = "";
-        example = ''
-            Option "Button2" "3"
-          '';
-        description = "Lines to be added to Wacom_eraser InputDevice section.";
-      };
-
-      cursorExtraConfig = mkOption {
-        default = "";
-        example = "";
-        description = "Lines to be added to Wacom_cursor InputDevice section.";
+          If you're not satisfied by the default behaviour you can override
+          <option>environment.etc."X11/xorg.conf.d/50-wacom.conf"</option> in
+          configuration.nix easily.
+        '';
       };
 
     };
@@ -64,54 +38,7 @@ in
 
     services.udev.packages = [ pkgs.xf86_input_wacom ];
 
-    services.xserver.serverLayoutSection =
-      ''
-        InputDevice "Wacom_stylus"
-        InputDevice "Wacom_eraser"
-        InputDevice "Wacom_cursor"
-      '';
-
-    services.xserver.config =
-      ''
-        Section "InputDevice"
-          Driver "wacom"
-          Identifier "Wacom_stylus"
-          ${optionalString (cfg.device != null) ''
-            Option "Device" "${cfg.device}"
-          ''}
-          Option "Type" "stylus"
-          ${optionalString (cfg.forceDeviceType != null) ''
-            Option "ForceDevice" "${cfg.forceDeviceType}"
-          ''}
-          ${cfg.stylusExtraConfig}
-        EndSection
-
-        Section "InputDevice"
-          Driver "wacom"
-          Identifier "Wacom_eraser"
-          ${optionalString (cfg.device != null) ''
-            Option "Device" "${cfg.device}"
-          ''}
-          Option "Type" "eraser"
-          ${optionalString (cfg.forceDeviceType != null) ''
-            Option "ForceDevice" "${cfg.forceDeviceType}"
-          ''}
-          ${cfg.eraserExtraConfig}
-        EndSection
-
-        Section "InputDevice"
-          Driver "wacom"
-          Identifier "Wacom_cursor"
-          ${optionalString (cfg.device != null) ''
-            Option "Device" "${cfg.device}"
-          ''}
-          Option "Type" "cursor"
-          ${optionalString (cfg.forceDeviceType != null) ''
-            Option "ForceDevice" "${cfg.forceDeviceType}"
-          ''}
-          ${cfg.cursorExtraConfig}
-        EndSection
-      '';
+    environment.etc."X11/xorg.conf.d/50-wacom.conf".source = "${pkgs.xf86_input_wacom}/share/X11/xorg.conf.d/50-wacom.conf";
 
   };
 

--- a/modules/services/x11/xserver.nix
+++ b/modules/services/x11/xserver.nix
@@ -433,6 +433,7 @@ in
         xorg.xlsclients
         xorg.xset
         xorg.xsetroot
+        xorg.xinput
         xorg.xprop
         pkgs.xterm
         pkgs.xdg_utils


### PR DESCRIPTION
- drop custom config:
  (please wacom using folks review this part and think
  about how to get it back if its important to you)
- put default config shipping with  xf86_input_wacom
  into /etc/X11/xorg.conf.d/
  which seems to be interpreted again when
  devices are hot plugged
- when starting x11, also provide xinput
  .. you never know when you need it

This fixes all problems I had:
- device only worked when plugged in, then xorg was started
  (an alternative quick fix is switching to terminal by ctrl-alt-F1 and back)
- I had to disable some devices, because eg myaint switched input
  device many times a sec rendering it unusable otherwise, some of those devices
  configured did not work.

Details:
http://sourceforge.net/apps/mediawiki/linuxwacom/index.php?title=FAQ#Is_hotplugging_supported_for_my_USB_tablet.3F
See 12 -> HAL or xorg.conf.d
