### PR TITLE
transmission.service: fix ignored ExecReload setting

### DIFF
--- a/modules/services/torrent/transmission.nix
+++ b/modules/services/torrent/transmission.nix
@@ -111,7 +111,7 @@ in
           ${pkgs.stdenv.shell} -c "chmod 770 ${homeDir}"
         '';
       serviceConfig.ExecStart = "${pkgs.transmission}/bin/transmission-daemon -f --port ${toString config.services.transmission.rpc_port}";
-      serviceConfig.ExecReload = "kill -HUP $MAINPID";
+      serviceConfig.ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       serviceConfig.User = "transmission";
       # NOTE: transmission has an internal umask that also must be set (in settings.json)
       serviceConfig.UMask = "0002";


### PR DESCRIPTION
This is what currently happens (from the journal log):

  [/nix/store/HASH-unit/transmission.service:27] Executable path is not absolute, ignoring: kill -HUP $MAINPID

Fix it by using absolute path to kill.
