### PR TITLE
add openvpn plugin to networkmanager

### DIFF
--- a/modules/services/networking/networkmanager.nix
+++ b/modules/services/networking/networkmanager.nix
@@ -130,7 +130,8 @@ in {
 
     security.polkit.permissions = polkitConf;
 
-    services.dbus.packages = cfg.packages;
+    # openvpn plugin has only dbus interface
+    services.dbus.packages = cfg.packages ++ [ networkmanager_openvpn ];
 
     services.udev.packages = cfg.packages;
   };


### PR DESCRIPTION
Currently networkmanager service supports specifying list of plugins to enable and configures udev, dbus and similar for the packages. 

I believe this is not the best approach since not all packages support all of that.

I currently add networkmanager_openvpn as default enabled, we should refactor that in near future when it becomes too messy.
