### PR TITLE
Set the domain name of the machine

### DIFF
--- a/modules/tasks/network-interfaces.nix
+++ b/modules/tasks/network-interfaces.nix
@@ -424,12 +424,16 @@ in
          // mapAttrs createBridgeDevice cfg.bridges
          // { "network-setup" = networkSetup; };
 
-    # Set the host name in the activation script.  Don't clear it if
-    # it's not configured in the NixOS configuration, since it may
-    # have been set by dhclient in the meantime.
+    # Set the host and domain names in the activation script.  Don't
+    # clear it if it's not configured in the NixOS configuration,
+    # since it may have been set by dhclient in the meantime.
     system.activationScripts.hostname =
       optionalString (config.networking.hostName != "") ''
         hostname "${config.networking.hostName}"
+      '';
+    system.activationScripts.domain =
+      optionalString (config.networking.domain != "") ''
+        domainname "${config.networking.domain}"
       '';
 
     services.udev.extraRules =


### PR DESCRIPTION
The domain name was not being set before, even if the administrator
properly configured the networking.domain option in
/etc/nixos/configuration.nix.
