### PR TITLE
lighttpd: add cgit sub-service

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -189,6 +189,7 @@
   ./services/web-servers/apache-httpd/default.nix
   ./services/web-servers/jboss/default.nix
   ./services/web-servers/lighttpd/default.nix
+  ./services/web-servers/lighttpd/cgit.nix
   ./services/web-servers/lighttpd/gitweb.nix
   ./services/web-servers/nginx/default.nix
   ./services/web-servers/tomcat.nix

--- a/modules/services/web-servers/lighttpd/cgit.nix
+++ b/modules/services/web-servers/lighttpd/cgit.nix
@@ -1,0 +1,71 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+  cfg = config.services.lighttpd.cgit;
+  configFile = pkgs.writeText "cgitrc"
+    ''
+      ${cfg.configText}
+    '';
+in
+{
+
+  options.services.lighttpd.cgit = {
+
+    enable = mkOption {
+      default = false;
+      type = types.uniq types.bool;
+      description = ''
+        If true, enable cgit (fast web interface for git repositories) as a
+        sub-service in lighttpd. cgit will be accessible at
+        http://yourserver/cgit
+      '';
+    };
+
+    configText = mkOption {
+      default = "";
+      example = ''
+        cache-size=1000
+        scan-path=/srv/git
+      '';
+      type = types.string;
+      description = ''
+        Verbatim contents of the cgit runtime configuration file. Documentation
+        (with cgitrc example file) is available in "man cgitrc". Or online:
+        http://git.zx2c4.com/cgit/tree/cgitrc.5.txt
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    # make the cgitrc manpage available
+    environment.systemPackages = [ pkgs.cgit ];
+
+    services.lighttpd.extraConfig = ''
+      server.modules += (
+        "mod_cgi",
+        "mod_alias",
+        "mod_setenv"
+      )
+
+      $HTTP["url"] =~ "^/cgit" {
+          cgi.assign = (
+              "cgit.cgi" => "${pkgs.cgit}/cgit/cgit.cgi"
+          )
+          alias.url = (
+              "/cgit.css" => "${pkgs.cgit}/cgit/cgit.css",
+              "/cgit.png" => "${pkgs.cgit}/cgit/cgit.png",
+              "/cgit"     => "${pkgs.cgit}/cgit/cgit.cgi"
+          )
+          setenv.add-environment = (
+              "CGIT_CONFIG" => "${configFile}"
+          )
+      }
+    '';
+
+  };
+
+}

--- a/modules/services/web-servers/lighttpd/default.nix
+++ b/modules/services/web-servers/lighttpd/default.nix
@@ -131,6 +131,12 @@ in
       description = "Lighttpd Web Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        ${if cfg.cgit.enable then ''
+          mkdir -p /var/cache/cgit
+          chown lighttpd:lighttpd /var/cache/cgit
+        '' else ""}
+      '';
       serviceConfig.ExecStart = "${pkgs.lighttpd}/sbin/lighttpd -D -f ${configFile}";
       # SIGINT => graceful shutdown
       serviceConfig.KillSignal = "SIGINT";


### PR DESCRIPTION
(cgit is "a hyperfast web frontend for git repositories written in C")

cgit is enabled like this (assuming lighttpd is already enabled):

```
  services.lighttpd.cgit.enable = true;
```

and configured verbatim like this (contents of the cgitrc file):

```
  services.lighttpd.cgit.configText = ''
    cache-size=1000
    scan-path=/srv/git
  '';
```

cgit will be available from this URL: http://yourserver/cgit

In lighttpd, I've ensured that the cache dir for cgit is created if cgit
is enabled.
