### PR TITLE
don't try to re-import pools on service change

### DIFF
--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -69,6 +69,7 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        restartIfChanged = false;
         ExecStart = "${kernel.zfs}/sbin/zpool import -f -a -d /dev";
       };
     };
@@ -84,8 +85,8 @@ in
         ExecStop = "${kernel.zfs}/sbin/zfs umount -a";
       };
     };
- 
-    system.fsPackages = [ kernel.zfs ];                  # XXX: needed? zfs doesn't have a fsck
+
+    system.fsPackages = [ kernel.zfs ];                  # XXX: needed? zfs doesn't have (need) a fsck
     environment.systemPackages = [ kernel.zfs ];
     services.udev.packages = [ kernel.zfs ];             # to hook zvol naming, etc. 
   };

--- a/modules/tasks/filesystems/zfs.nix
+++ b/modules/tasks/filesystems/zfs.nix
@@ -81,6 +81,7 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        restartIfChanged = false;
         ExecStart = "${kernel.zfs}/sbin/zfs mount -a";
         ExecStop = "${kernel.zfs}/sbin/zfs umount -a";
       };


### PR DESCRIPTION
When nixos-rebuild grabs a new kernel, it will build new spl/zfs
modules, which will change the service. On completion nixos will try and
restart the services which will try and import pools again, and
generally will fail.

The pools are already imported, we don't need to do it again..
