### PR TITLE
postgresql: Improve and cleanup module.

### DIFF
--- a/modules/services/databases/postgresql.nix
+++ b/modules/services/databases/postgresql.nix
@@ -33,7 +33,13 @@ let
       ${cfg.extraConfig}
     '';
 
-  pre84 = versionOlder (builtins.parseDrvName postgresql.name).version "8.4";
+  version = (builtins.parseDrvName postgresql.name).version;
+  localAuthMethod =
+    if !versionOlder version "9.1"
+      then "peer"
+    else if versionOlder version "8.4"
+      then "ident sameuser"
+    else "ident";
 
 in
 
@@ -140,7 +146,7 @@ in
     services.postgresql.authentication =
       ''
         # Generated file; do not edit!
-        local all all              ident ${optionalString pre84 "sameuser"}
+        local all all              ${localAuthMethod}
         host  all all 127.0.0.1/32 md5
         host  all all ::1/128      md5
       '';

--- a/modules/services/databases/postgresql.nix
+++ b/modules/services/databases/postgresql.nix
@@ -100,14 +100,6 @@ in
         '';
       };
 
-      authMethod = mkOption {
-        default = " ident sameuser ";
-        description = ''
-          How to authorize users.
-          Note: ident needs absolute trust to all allowed client hosts.
-        '';
-      };
-
       enableTCPIP = mkOption {
         default = false;
         description = ''

--- a/modules/services/databases/postgresql.nix
+++ b/modules/services/databases/postgresql.nix
@@ -22,11 +22,10 @@ let
 
   postgresql = postgresqlAndPlugins cfg.package;
 
-  flags = optional cfg.enableTCPIP "-i";
-
   # The main PostgreSQL configuration file.
   configFile = pkgs.writeText "postgresql.conf"
     ''
+      listen_addresses = '${cfg.listenAddresses}'
       hba_file = '${pkgs.writeText "pg_hba.conf" cfg.authentication}'
       ident_file = '${pkgs.writeText "pg_ident.conf" cfg.identMap}'
       log_destination = 'syslog'
@@ -100,10 +99,17 @@ in
         '';
       };
 
-      enableTCPIP = mkOption {
-        default = false;
+      listenAddresses = mkOption {
+        default = "";
+        example = "localhost";
         description = ''
-          Whether to run PostgreSQL with -i flag to enable TCP/IP connections.
+          Specifies the TCP/IP address(es) on which the server is to listen for
+          connections from client applications. Use the default ("") in order to
+          not listen to TCP/IP at all and only accept Unix-domain sockets.
+
+          For more information about this value, please have a look at:
+
+          http://www.postgresql.org/docs/9.2/static/runtime-config-connection.html#GUC-LISTEN-ADDRESSES
         '';
       };
 
@@ -177,7 +183,7 @@ in
           ''; # */
 
         serviceConfig =
-          { ExecStart = "@${postgresql}/bin/postgres postgres ${toString flags}";
+          { ExecStart = "@${postgresql}/bin/postgres postgres";
             User = "postgres";
             Group = "postgres";
             PermissionsStartOnly = true;

--- a/modules/services/databases/postgresql.nix
+++ b/modules/services/databases/postgresql.nix
@@ -98,9 +98,10 @@ in
         '';
         description = ''
           Defines how users authenticate themselves to the server.
-          This is in the format of the pg_hba.conf, for documentation, see:
 
-          http://www.postgresql.org/docs/9.2/static/auth-pg-hba-conf.html
+          This is in the format of <link
+          xlink:href="http://www.postgresql.org/docs/9.2/static/auth-pg-hba-conf.html">the
+          <filename>pg_hba.conf</filename> configuration file</link>.
         '';
       };
 
@@ -119,9 +120,8 @@ in
           connections from client applications. Use the default ("") in order to
           not listen to TCP/IP at all and only accept Unix-domain sockets.
 
-          For more information about this value, please have a look at:
-
-          http://www.postgresql.org/docs/9.2/static/runtime-config-connection.html#GUC-LISTEN-ADDRESSES
+          For more information on this value, please visit <link
+          xlink:href="http://www.postgresql.org/docs/9.2/static/runtime-config-connection.html#GUC-LISTEN-ADDRESSES"/>.
         '';
       };
 


### PR DESCRIPTION
Essentially why I'm doing a pull request instead of directly pushing here is because of a6c2e79af979530769e0727bf51a735e3f3f1297, which could break configurations out there.

At the current master `enableTCPIP` has no effect at all, because of the reason I described in the mentioned commit.

So, with this commit, it will essentially break configurations where users have just ignored `enableTCPIP`, which leads to PostgreSQL listening to local TCP/IP connections by default (which I presume wasn't intended, because `enableTCPIP` defaults to `false`).

Which brings me to the main question: Should we enable listening to local TCP/IP connections by default?
