### PR TITLE
lighttpd: improve module handling

### DIFF
--- a/modules/services/web-servers/lighttpd/cgit.nix
+++ b/modules/services/web-servers/lighttpd/cgit.nix
@@ -45,12 +45,6 @@ in
     environment.systemPackages = [ pkgs.cgit ];
 
     services.lighttpd.extraConfig = ''
-      server.modules += (
-        "mod_cgi",
-        "mod_alias",
-        "mod_setenv"
-      )
-
       $HTTP["url"] =~ "^/cgit" {
           cgi.assign = (
               "cgit.cgi" => "${pkgs.cgit}/cgit/cgit.cgi"

--- a/modules/services/web-servers/lighttpd/gitweb.nix
+++ b/modules/services/web-servers/lighttpd/gitweb.nix
@@ -45,12 +45,6 @@ in
   config = mkIf cfg.enable {
 
     services.lighttpd.extraConfig = ''
-      server.modules += (
-        "mod_alias",
-        "mod_cgi",
-        "mod_redirect",
-        "mod_setenv"
-      )
       $HTTP["url"] =~ "^/gitweb" {
           cgi.assign = (
               ".cgi" => "${pkgs.perl}/bin/perl"


### PR DESCRIPTION
lighttpd doesn't support loading a module more than once. If you attempt
to load a module again, lighttpd prints an error message:

  (plugin.c.131) Cannot load plugin mod_cgi more than once, please fix your config (we may not accept such configs in future releases

And it's not just the error message. The module isn't loaded (or is
messed up somehow) so that neither sub-service will work properly after
this.

This is bad news for the current approach to sub-services, where each
sub-service lists the needed modules in a server.modules += (...) block.
When two sub-services need the same module we get the above issue. (And,
AFAIK, there is no way to check if a module is already loaded either.)

First I thought about an approach where each sub-service specifies the
list of plugins it needs, and that a common server.modules = (...) list
is built from the union of those lists. That would loosly couple the
sub-services with the main lighttpd nixos module expression. But I think
this is a bad idea because lighttpd module loading order matters[1], and
the module order in the global server.modules = (...) list would be
somewhat cumbersome to control.

Here is an example:

Sub-service A needs mod_fastcgi. Sub-service B needs mod_auth and
mod_fastcgi. Note that mod_auth must be loaded _before_ mod_fastcgi to
take effect. The union of those modules may either be ["mod_auth"
"mod_fastcgi"] or ["mod_fastcgi" "mod_auth"] depending on the evaluation
order. The first order will work, the latter will not.

So instead of the above, this commit moves the modules from
service.modules += (...) snippets in each sub-service to a global
server.modules = (...) list in the main lighttpd module expression. The
module loading order is fixed and each module is included only if any of
the sub-services that needs it is enabled.

The downside to this approach is that sub-services need a (tiny) bit of
change to the main lighttpd nixos module expression. But I think it is
the only sane way to do it (as long as lighttpd is written the way it
is).

References:
  [1] http://redmine.lighttpd.net/projects/1/wiki/Server_modulesDetails
  [2] http://redmine.lighttpd.net/issues/2337
