### PR TITLE
Tarball should get ip from dhcp even if booting from nfs

### DIFF
--- a/modules/installer/cd-dvd/system-tarball.nix
+++ b/modules/installer/cd-dvd/system-tarball.nix
@@ -72,9 +72,6 @@ in
     inherit (config.tarball) contents storeContents;
   };
 
-  # Otherwise it will collide with the 'ip=dhcp' kernel autoconfig.
-  networking.useDHCP = false;
-
   boot.postBootCommands =
     ''
       # After booting, register the contents of the Nix store on the


### PR DESCRIPTION
Disabling DHCP only causes problems, rather than solving them. Even on computers booting from nfs it's not a problem to request for an ip using DHCP client, and it's rather needed if you want to report hostname to dhcp server.
