### PR TITLE
Document that extraUsers options apply to root

### DIFF
--- a/modules/config/users-groups.nix
+++ b/modules/config/users-groups.nix
@@ -160,6 +160,7 @@ in
       };
       description = ''
         Additional user accounts to be created automatically by the system.
+        This can also be used to set options for root.
       '';
       options = [ userOpts ];
     };


### PR DESCRIPTION
This is important because the newbie wants to know if `users.extraUsers.root.openssh.authorizedKeys.keys` will have any effect - this isn't documented anywhere in the manual right now.
