### PR TITLE
nixos-rebuild: support -vv, -vvv, -vvvv, and -vvvvv

### DIFF
--- a/modules/installer/tools/nixos-rebuild.sh
+++ b/modules/installer/tools/nixos-rebuild.sh
@@ -76,7 +76,7 @@ while [ "$#" -gt 0 ]; do
         repair=1
         extraBuildFlags+=("$i")
         ;;
-      --show-trace|--no-build-hook|--keep-failed|-K|--keep-going|-k|--verbose|-v|--fallback|--repair)
+      --show-trace|--no-build-hook|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair)
         extraBuildFlags+=("$i")
         ;;
       --max-jobs|-j|--cores|-I)


### PR DESCRIPTION
I ran into a case where I needed to use `-vvvv` on `nixos-rebuild`, and got tripped up for a while before I read the source and realized I needed to use `-v -v -v -v`.  This patch makes `nixos-rebuild` support the other single-character argument combinations.  Tested manually.
