### PR TITLE
Add /etc/ssl/certs/ca-certificates.crt symlink for Ubuntu compatibility

### DIFF
--- a/modules/security/ca.nix
+++ b/modules/security/ca.nix
@@ -7,8 +7,15 @@ with pkgs.lib;
   config = {
 
     environment.etc =
-      [ { source = "${pkgs.cacert}/etc/ca-bundle.crt";
-          target = "ssl/certs/ca-bundle.crt";
+      [
+        # Provide both Fedora and Ubuntu certificate locations for
+        # compatibility.
+        { source = "${pkgs.cacert}/etc/ca-bundle.crt";
+          target = "ssl/certs/ca-bundle.crt"; # Same location as in Fedora
+        }
+
+        { source = "${pkgs.cacert}/etc/ca-bundle.crt";
+          target = "ssl/certs/ca-certificates.crt"; # Same location as in Ubuntu
         }
 
         # Backward compatibility; may remove at some point.


### PR DESCRIPTION
Fedora uses ca-bundle.crt. Ubuntu uses ca-certificates.crt. Supply both
to be compatible. Example use case: a ~/.msmtprc file that is used with
NixOS/Fedora or NixOS/Ubuntu. (We cannot do anything about Fedora/Ubuntu
differences.)
