### PR TITLE
minidlna: Start after networking.target.

### DIFF
--- a/modules/services/networking/minidlna.nix
+++ b/modules/services/networking/minidlna.nix
@@ -84,6 +84,7 @@ in
       { description = "MiniDLNA Server";
 
         wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
 
         preStart =
           ''


### PR DESCRIPTION
This hopefully fixes start of minidlna on boot.
