### PR TITLE
Remove unclear comment from hardware-configuration.nix

### DIFF
--- a/modules/installer/tools/nixos-hardware-scan.pl
+++ b/modules/installer/tools/nixos-hardware-scan.pl
@@ -229,6 +229,7 @@ my $modulePackages = toNixExpr(removeDups @modulePackages);
 my $attrs = multiLineList("  ", removeDups @attrs);
 my $requires = multiLineList("    ", removeDups @requires);
 
+
 print <<EOF ;
 # This file contains basic hardware configuration, detected 
 # through nixos-hardware-scan at initial NixOS installation time.

--- a/modules/installer/tools/nixos-hardware-scan.pl
+++ b/modules/installer/tools/nixos-hardware-scan.pl
@@ -229,10 +229,8 @@ my $modulePackages = toNixExpr(removeDups @modulePackages);
 my $attrs = multiLineList("  ", removeDups @attrs);
 my $requires = multiLineList("    ", removeDups @requires);
 
-
 print <<EOF ;
-# This is a generated file.  Do not modify!
-# Make changes to /etc/nixos/configuration.nix instead.
+# This file contains basic hardware configuration, detected through nixos-hardware-scan
 { config, pkgs, ... }:
 
 {

--- a/modules/installer/tools/nixos-hardware-scan.pl
+++ b/modules/installer/tools/nixos-hardware-scan.pl
@@ -230,7 +230,8 @@ my $attrs = multiLineList("  ", removeDups @attrs);
 my $requires = multiLineList("    ", removeDups @requires);
 
 print <<EOF ;
-# This file contains basic hardware configuration, detected through nixos-hardware-scan
+# This file contains basic hardware configuration, detected 
+# through nixos-hardware-scan at initial NixOS installation time.
 { config, pkgs, ... }:
 
 {


### PR DESCRIPTION
It is likely that hardware-configuration.nix is generated once (just like configuration.nix) and never regenerated again. Looking into `nixos-option.sh`:

``` sh
hardware_config="${NIXOS_CONFIG%/configuration.nix}/hardware-configuration.nix"
  if test -e "$hardware_config"; then
    echo "A hardware configuration file exists, generation skipped."
  else
    echo "Generating a hardware configuration file in $hardware_config..."
    nixos-hardware-scan > "$hardware_config"
  fi
```
