### PR TITLE
RFC for zfs tests. 

### DIFF
--- a/doc/manual/installation.xml
+++ b/doc/manual/installation.xml
@@ -84,12 +84,33 @@ $ lvcreate --size 1G --name smalldisk MyVolGroup</screen>
     <listitem><para>For creating software RAID devices, use
     <command>mdadm</command>.</para></listitem>
 
+    <listitem><para>For creating ZFS pools, the zfs commands, e.g.,
+
+<screen>
+$ zpool create zroot /dev/sda2 .... 
+$ zfs create zroot/root </screen>
+
+    </para></listitem>
+  
   </itemizedlist>
 
   </para></listitem>
 
   <listitem><para>Mount the target file system on which NixOS should
-  be installed on <filename>/mnt</filename>.</para></listitem>
+  be installed on <filename>/mnt</filename>.</para>
+  
+    <itemizedlist>
+      <listitem><para> If you're using a ZFS root, then you'll need to mark it as a legacy mount for the NixOS initrd to properly mount it. 
+      ZFS root also requires requires a separate <filename>/boot</filename> partition. 
+<screen>
+$ zfs set mountpoint=legacy zroot/root
+$ mount -t zfs zroot/root /mnt
+$ mkfs.ext3 -L boot /dev/sda1
+$ mkdir /mnt/boot
+$ mount LABEL=boot /mnt/boot </screen>
+    </para></listitem>
+    </itemizedlist>
+  </listitem>
 
   <listitem>
 

--- a/lib/test-driver/Machine.pm
+++ b/lib/test-driver/Machine.pm
@@ -30,7 +30,7 @@ sub new {
     if (!$startCommand) {
         # !!! merge with qemu-vm.nix.
         $startCommand =
-            "qemu-kvm -m 384 " .
+            "qemu-kvm -m 768 " .
             "-net nic,model=virtio \$QEMU_OPTS ";
         my $iface = $args->{hdaInterface} || "virtio";
         $startCommand .= "-drive file=" . Cwd::abs_path($args->{hda}) . ",if=$iface,boot=on,werror=report "

--- a/modules/profiles/base.nix
+++ b/modules/profiles/base.nix
@@ -50,6 +50,6 @@
   ];
 
   # Include support for various filesystems.
-  boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" ];
+  boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" "zfs" ];
 
 }

--- a/modules/virtualisation/qemu-vm.nix
+++ b/modules/virtualisation/qemu-vm.nix
@@ -199,11 +199,11 @@ let
           -virtfs local,path=$TMPDIR/xchg,security_model=none,mount_tag=xchg \
           -virtfs local,path=''${SHARED_DIR:-$TMPDIR/xchg},security_model=none,mount_tag=shared \
           ${if cfg.useBootLoader then ''
-            -drive index=0,id=drive1,file=$NIX_DISK_IMAGE,if=virtio,cache=writeback,werror=report \
+            -drive index=0,id=drive1,file=$NIX_DISK_IMAGE,if=virtio,cache=writethrough,werror=report \
             -drive index=1,id=drive2,file=${bootDisk}/disk.img,if=virtio,readonly \
             -boot menu=on
           '' else ''
-            -drive file=$NIX_DISK_IMAGE,if=virtio,cache=writeback,werror=report \
+            -drive file=$NIX_DISK_IMAGE,if=virtio,cache=writethrough,werror=report \
             -kernel ${config.system.build.toplevel}/kernel \
             -initrd ${config.system.build.toplevel}/initrd \
             -append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init regInfo=${regInfo} ${kernelConsole} $QEMU_KERNEL_PARAMS" \

--- a/release.nix
+++ b/release.nix
@@ -249,6 +249,7 @@ in {
       installer.rebuildCD = runTest (t: t.installer.rebuildCD.test);
       installer.separateBoot = runTest (t: t.installer.separateBoot.test);
       installer.simple = runTest (t: t.installer.simple.test);
+      installer.zroot = runTest (t: t.installer.zroot.test);
       #installer.swraid = runTest (t: t.installer.swraid.test);
       ipv6 = runTest (t: t.ipv6.test);
       kde4 = runTest (t: t.kde4.test);

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -29,4 +29,5 @@ with import ../lib/testing.nix { inherit system minimal; };
   tomcat = makeTest (import ./tomcat.nix);
   trac = makeTest (import ./trac.nix);
   xfce = makeTest (import ./xfce.nix);
+  ztest = makeTest (import ./ztest.nix);
 }

--- a/tests/installer.nix
+++ b/tests/installer.nix
@@ -59,6 +59,7 @@ let
 
   zRootFS =
     ''
+      boot.initrd.supportedFilesystems = [ "ext3" "zfs" ];
       fileSystems."/".device = "zroot/root";
       fileSystems."/".fsType = "zfs";
     '';
@@ -316,12 +317,15 @@ in {
               "parted /dev/vda -- mkpart primary 1M 50MB", # /boot
               "parted /dev/vda -- mkpart primary 50MB 2048M",
               "udevadm settle",
-              "zpool create zroot /dev/vda2",         # start a pool 
-              "zfs create zroot/root",                # create root
-              "zfs set mountpoint=legacy zroot/root", # mount this fs with 'mount' instead of 'zfs mount'
-              "zfs set compression=lz4 zroot/root",   # compress things a bit, so we don't run out of space. 
-              "mount -t zfs zroot/root /mnt",          
-              "zfs create -V 512M -b 4K zroot/swap",  # create a swap zvol
+              "zpool create zroot /dev/vda2",             # start a pool 
+              "zfs create zroot/root",                    # create root
+              "zfs set mountpoint=legacy zroot/root",     # mount this fs with 'mount' instead of 'zfs mount'
+              "zfs set compression=lz4 zroot/root",       # compress things a bit, so we don't run out of space. 
+              "mount -t zfs zroot/root /mnt",              
+              "zfs create -V 1G -b 4K zroot/swap",        # create a swap zvol
+              "zfs set compression=off zroot/swap",       # don't compress swap
+              "zfs set primarycache=metadata zroot/swap", # only cache metadata
+              "zfs set sync=always zroot/swap",
               "mkswap -L swap /dev/zvol/zroot/swap",  
               "swapon -L swap",
               "mkfs.ext3 -L boot /dev/vda1",          # separate boot partition

--- a/tests/ztest.nix
+++ b/tests/ztest.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+
+{
+  nodes = {
+    machine =
+      { pkgs, config, ... }:
+
+      {
+        virtualisation.emptyDiskImages = [ 4096 ];
+        boot.supportedFilesystems = [ "zfs" "ext4" ] ; 
+      };
+  };
+
+  testScript = ''
+    startAll;
+
+    $machine->waitForUnit("default.target");
+
+    # this is a work in progress, it currently fails with:
+    #   pack/bigT mismatch in 0x7f5ff010cf60/0x7f5ff068fea8
+    # probably some disk io synchronization problems. 
+
+    # we don't directly create a zfs filesystem here we create a ext3
+    # filesystem and the the zfs unit tests use it.. 
+
+    $machine->succeed("mkfs.ext3 -L ztest /dev/vdb");
+    $machine->succeed("mkdir /ztest");
+    $machine->succeed("mount LABEL=ztest /ztest");
+    $machine->succeed("echo Running ZFS unit tests, this may take a while...");
+    $machine->succeed("ztest -f /ztest -t1 -VVV");  # single threaded
+    $machine->shutdown;
+  '';
+}


### PR DESCRIPTION
This is a work in process. This isn't intended for merging quite yet.. 

This patchset adds support, documentation, and tests for installing NixOS to a ZFS partition. Booting off of ZFS is probably possible with a sufficient of grub-fu, but currently only separate boot/root is tested. 

There is also a new test for running the zfs unit tests. 

Dodgy bits:
- I had to bump up the amount of memory for the VMs from 384MiB to 768MiB. Don't know a way around this, but maybe we could isolate it to this test?
- I changed the qemu cache policy for the virtual drives from 'writeback' to 'writethrough', as ztest was failing
- I added 'zfs' to supported filesystems on the ISO. I'm not sure if this makes the ISO distributable (because of the CDDL). This is probably fixable by installing the zfs software/kernel modules before creating the filesystems, but I'm not sure the best way to do that. 
