### PR TITLE
Add services.samba.nsswins option

### DIFF
--- a/modules/config/nsswitch.nix
+++ b/modules/config/nsswitch.nix
@@ -7,6 +7,7 @@ with pkgs.lib;
 let
 
   inherit (config.services.avahi) nssmdns;
+  inherit (config.services.samba) nsswins;
 
 in
 
@@ -43,7 +44,7 @@ in
               passwd:    files ldap
               group:     files ldap
               shadow:    files ldap
-              hosts:     files ${optionalString nssmdns "mdns_minimal [NOTFOUND=return]"} dns ${optionalString nssmdns "mdns"} myhostname
+              hosts:     files ${optionalString nssmdns "mdns_minimal [NOTFOUND=return]"} dns ${optionalString nssmdns "mdns"} ${optionalString nsswins "wins"} myhostname
               networks:  files dns
               ethers:    files
               services:  files

--- a/modules/services/network-filesystems/samba.nix
+++ b/modules/services/network-filesystems/samba.nix
@@ -170,6 +170,16 @@ in
         example = "share";
       };
 
+      nsswins = mkOption {
+        default = false;
+        type = types.uniq types.bool;
+        description = ''
+          Whether to enable the WINS NSS (Name Service Switch) plug-in.
+          Enabling it allows applications to resolve WINS/NetBIOS names (a.k.a.
+          Windows machine names) by transparently querying the winbindd daemon.
+        '';
+      };
+
     };
 
   };
@@ -195,6 +205,8 @@ in
         };
 
         users.extraGroups.smbguest.gid = config.ids.uids.smbguest;
+
+        system.nssModules = optional cfg.nsswins samba;
 
         systemd = {
           targets.samba = {


### PR DESCRIPTION
This option allows for seamless WINS/NetBIOS name lookup, using
nsswitch.

Built and tested.
