### PR TITLE
stage-2-init: create /var/lib and /var/db at boot, so some modules that create user home folders here don't fail

### DIFF
--- a/modules/system/boot/stage-2-init.sh
+++ b/modules/system/boot/stage-2-init.sh
@@ -86,7 +86,7 @@ mount -t tmpfs -o "rw,nosuid,nodev,size=@devShmSize@" tmpfs /dev/shm
 mkdir -m 0755 -p /dev/pts
 [ -e /proc/bus/usb ] && mount -t usbfs none /proc/bus/usb # UML doesn't have USB by default
 mkdir -m 01777 -p /tmp
-mkdir -m 0755 -p /var /var/log
+mkdir -m 0755 -p /var /var/log /var/lib /var/db
 mkdir -m 0755 -p /nix/var
 mkdir -m 0700 -p /root
 mkdir -m 0755 -p /bin # for the /bin/sh symlink


### PR DESCRIPTION
It was pretty nasty bug, that was hard to spot. But as soon as i started doing vm tests i saw that happening.

For example lets say this module snippet from bacula (to show this is not related only with my modules):

```
    libDir = "/var/lib/bacula";

    users.extraUsers.bacula = {
      group = "bacula";
      uid = config.ids.uids.bacula;
      home = "${libDir}";
      createHome = true;
      description = "Bacula Daemons user";
      shell = "${pkgs.bash}/bin/bash";
    };
```

There's no way this home will be created on boot, because when `useradd` tries to create home `/var/lib/` does not  yet exist.
